### PR TITLE
feat: dual-mode terminal with Claude/Bash toggle

### DIFF
--- a/src/components/ConfigureShortcuts.tsx
+++ b/src/components/ConfigureShortcuts.tsx
@@ -51,6 +51,14 @@ const ConfigureShortcuts: React.FC<ConfigureShortcutsProps> = ({
 			value: 'returnToMenu',
 		},
 		{
+			label: `Cancel: ${getShortcutDisplayFromState('cancel')}`,
+			value: 'cancel',
+		},
+		{
+			label: `Toggle Mode: ${getShortcutDisplayFromState('toggleMode')}`,
+			value: 'toggleMode',
+		},
+		{
 			label: '---',
 			value: 'separator',
 		},

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -38,8 +38,8 @@ const Session: React.FC<SessionProps> = ({
 
 		// Set up bash data handler for history management
 		bashPty.onData((data: string) => {
-			// Only write to stdout if we're in bash mode
-			if (currentMode === 'bash' && !isExiting) {
+			// Only write to stdout if we're in bash mode (check session state directly)
+			if (session.currentMode === 'bash' && !isExiting) {
 				stdout.write(data);
 			}
 
@@ -65,7 +65,7 @@ const Session: React.FC<SessionProps> = ({
 
 		session.bashProcess = bashPty;
 		return bashPty;
-	}, [session, currentMode, isExiting, stdout]);
+	}, [session, isExiting, stdout]);
 
 	// Display mode indicator
 	const displayModeIndicator = useCallback(
@@ -117,8 +117,8 @@ const Session: React.FC<SessionProps> = ({
 			// Display mode indicator first
 			displayModeIndicator('claude');
 
-			// Trigger Claude history restoration
-			sessionManager.emit('sessionRestore', session);
+			// Claude history restoration will be triggered automatically by setSessionActive
+			// when useEffect re-runs due to mode change
 		}
 	}, [
 		currentMode,
@@ -324,7 +324,6 @@ const Session: React.FC<SessionProps> = ({
 		onReturnToMenu,
 		isExiting,
 		createBashProcess,
-		currentMode,
 		displayModeIndicator,
 		toggleMode,
 	]);

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -1,8 +1,9 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useCallback} from 'react';
 import {useStdout} from 'ink';
-import {Session as SessionType} from '../types/index.js';
+import {Session as SessionType, TerminalMode} from '../types/index.js';
 import {SessionManager} from '../services/sessionManager.js';
 import {shortcutManager} from '../services/shortcutManager.js';
+import {spawn} from 'node-pty';
 
 interface SessionProps {
 	session: SessionType;
@@ -17,6 +18,110 @@ const Session: React.FC<SessionProps> = ({
 }) => {
 	const {stdout} = useStdout();
 	const [isExiting, setIsExiting] = useState(false);
+	const [currentMode, setCurrentMode] = useState<TerminalMode>(
+		session.currentMode,
+	);
+
+	// Create bash PTY process
+	const createBashProcess = useCallback(() => {
+		if (session.bashProcess) {
+			return session.bashProcess;
+		}
+
+		const bashPty = spawn('/bin/bash', [], {
+			name: 'xterm-color',
+			cols: process.stdout.columns || 80,
+			rows: process.stdout.rows || 24,
+			cwd: session.worktreePath,
+			env: process.env,
+		});
+
+		// Set up bash data handler for history management
+		bashPty.onData((data: string) => {
+			// Only write to stdout if we're in bash mode
+			if (currentMode === 'bash' && !isExiting) {
+				stdout.write(data);
+			}
+
+			// Store bash history with memory management
+			const buffer = Buffer.from(data, 'utf8');
+			session.bashHistory.push(buffer);
+
+			// Apply 5MB memory limit for bash history
+			const MAX_BASH_HISTORY = 5 * 1024 * 1024;
+			let totalSize = session.bashHistory.reduce(
+				(sum, buf) => sum + buf.length,
+				0,
+			);
+			while (totalSize > MAX_BASH_HISTORY && session.bashHistory.length > 0) {
+				const removed = session.bashHistory.shift();
+				if (removed) totalSize -= removed.length;
+			}
+
+			// Update bash state (simple prompt detection)
+			session.bashState =
+				data.includes('$ ') || data.includes('# ') ? 'idle' : 'running';
+		});
+
+		session.bashProcess = bashPty;
+		return bashPty;
+	}, [session, currentMode, isExiting, stdout]);
+
+	// Display mode indicator
+	const displayModeIndicator = useCallback(
+		(mode: TerminalMode) => {
+			const indicator =
+				mode === 'claude'
+					? '\x1b[44m Claude \x1b[0m \x1b[90m(Ctrl+T: Bash)\x1b[0m'
+					: '\x1b[42m Bash \x1b[0m \x1b[90m(Ctrl+T: Claude)\x1b[0m';
+
+			// Display in status line at top of terminal
+			stdout.write(`\x1b[s\x1b[1;1H${indicator}\x1b[u`);
+		},
+		[stdout],
+	);
+
+	// Mode switching function
+	const toggleMode = useCallback(() => {
+		if (currentMode === 'claude') {
+			// Switching to bash mode
+			createBashProcess();
+
+			// Clear screen for mode switch
+			stdout.write('\x1B[2J\x1B[H');
+
+			// Restore bash history
+			session.bashHistory.forEach(buffer => {
+				stdout.write(buffer);
+			});
+
+			setCurrentMode('bash');
+			session.currentMode = 'bash';
+
+			// Display mode indicator
+			displayModeIndicator('bash');
+		} else {
+			// Switching to claude mode
+			setCurrentMode('claude');
+			session.currentMode = 'claude';
+
+			// Clear screen for mode switch
+			stdout.write('\x1B[2J\x1B[H');
+
+			// Trigger Claude history restoration
+			sessionManager.emit('sessionRestore', session);
+
+			// Display mode indicator
+			displayModeIndicator('claude');
+		}
+	}, [
+		currentMode,
+		createBashProcess,
+		session,
+		sessionManager,
+		stdout,
+		displayModeIndicator,
+	]);
 
 	useEffect(() => {
 		if (!stdout) return;
@@ -55,6 +160,11 @@ const Session: React.FC<SessionProps> = ({
 
 		// Mark session as active (this will trigger the restore event)
 		sessionManager.setSessionActive(session.worktreePath, true);
+
+		// Display initial mode indicator
+		setTimeout(() => {
+			displayModeIndicator(currentMode);
+		}, 100);
 
 		// Immediately resize the PTY and terminal to current dimensions
 		// This fixes rendering issues when terminal width changed while in menu
@@ -95,10 +205,24 @@ const Session: React.FC<SessionProps> = ({
 		const handleResize = () => {
 			const cols = process.stdout.columns || 80;
 			const rows = process.stdout.rows || 24;
-			session.process.resize(cols, rows);
-			// Also resize the virtual terminal
-			if (session.terminal) {
-				session.terminal.resize(cols, rows);
+
+			// Resize Claude PTY and virtual terminal
+			try {
+				session.process.resize(cols, rows);
+				if (session.terminal) {
+					session.terminal.resize(cols, rows);
+				}
+			} catch {
+				// Process might have exited
+			}
+
+			// Resize bash PTY if it exists
+			if (session.bashProcess) {
+				try {
+					session.bashProcess.resize(cols, rows);
+				} catch {
+					// Bash process might have exited
+				}
 			}
 		};
 
@@ -119,12 +243,13 @@ const Session: React.FC<SessionProps> = ({
 		const handleStdinData = (data: string) => {
 			if (isExiting) return;
 
-			// Check for return to menu shortcut
-			const returnToMenuShortcut = shortcutManager.getShortcuts().returnToMenu;
-			const shortcutCode =
-				shortcutManager.getShortcutCode(returnToMenuShortcut);
+			const shortcuts = shortcutManager.getShortcuts();
 
-			if (shortcutCode && data === shortcutCode) {
+			// Check for return to menu shortcut
+			const returnToMenuCode = shortcutManager.getShortcutCode(
+				shortcuts.returnToMenu,
+			);
+			if (returnToMenuCode && data === returnToMenuCode) {
 				// Disable focus reporting mode before returning to menu
 				if (stdout) {
 					stdout.write('\x1b[?1004l');
@@ -137,8 +262,23 @@ const Session: React.FC<SessionProps> = ({
 				return;
 			}
 
-			// Pass all other input directly to the PTY
-			session.process.write(data);
+			// Check for mode toggle shortcut (Ctrl+T)
+			const toggleModeCode = shortcutManager.getShortcutCode(
+				shortcuts.toggleMode,
+			);
+			if (toggleModeCode && data === toggleModeCode) {
+				toggleMode();
+				return;
+			}
+
+			// Route input to appropriate PTY based on current mode
+			if (currentMode === 'claude') {
+				session.process.write(data);
+			} else {
+				// Bash mode - create bash process if needed and write to it
+				const bashPty = createBashProcess();
+				bashPty.write(data);
+			}
 		};
 
 		stdin.on('data', handleStdinData);
@@ -171,7 +311,17 @@ const Session: React.FC<SessionProps> = ({
 			sessionManager.off('sessionExit', handleSessionExit);
 			stdout.off('resize', handleResize);
 		};
-	}, [session, sessionManager, stdout, onReturnToMenu, isExiting]);
+	}, [
+		session,
+		sessionManager,
+		stdout,
+		onReturnToMenu,
+		isExiting,
+		createBashProcess,
+		currentMode,
+		displayModeIndicator,
+		toggleMode,
+	]);
 
 	// Return null to render nothing (PTY output goes directly to stdout)
 	return null;

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -87,19 +87,25 @@ const Session: React.FC<SessionProps> = ({
 			// Switching to bash mode
 			createBashProcess();
 
-			// Clear screen for mode switch
-			stdout.write('\x1B[2J\x1B[H');
-
-			// Restore bash history
-			session.bashHistory.forEach(buffer => {
-				stdout.write(buffer);
-			});
-
+			// Set current mode first
 			setCurrentMode('bash');
 			session.currentMode = 'bash';
 
-			// Display mode indicator
+			// Clear screen and prepare for bash
+			stdout.write('\x1B[2J\x1B[H');
+
+			// Display mode indicator first
 			displayModeIndicator('bash');
+
+			// If bash history exists, restore it
+			if (session.bashHistory.length > 0) {
+				session.bashHistory.forEach(buffer => {
+					stdout.write(buffer);
+				});
+			} else {
+				// First time switching to bash - let the PTY send its initial prompt
+				// The bash prompt will appear naturally from the PTY data handler
+			}
 		} else {
 			// Switching to claude mode
 			setCurrentMode('claude');
@@ -108,11 +114,11 @@ const Session: React.FC<SessionProps> = ({
 			// Clear screen for mode switch
 			stdout.write('\x1B[2J\x1B[H');
 
+			// Display mode indicator first
+			displayModeIndicator('claude');
+
 			// Trigger Claude history restoration
 			sessionManager.emit('sessionRestore', session);
-
-			// Display mode indicator
-			displayModeIndicator('claude');
 		}
 	}, [
 		currentMode,

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -70,10 +70,11 @@ const Session: React.FC<SessionProps> = ({
 	// Display mode indicator
 	const displayModeIndicator = useCallback(
 		(mode: TerminalMode) => {
+			const toggleShortcut = shortcutManager.getShortcutDisplay('toggleMode');
 			const indicator =
 				mode === 'claude'
-					? '\x1b[44m Claude \x1b[0m \x1b[90m(Ctrl+T: Bash)\x1b[0m'
-					: '\x1b[42m Bash \x1b[0m \x1b[90m(Ctrl+T: Claude)\x1b[0m';
+					? `\x1b[44m Claude \x1b[0m \x1b[90m(${toggleShortcut}: Bash)\x1b[0m`
+					: `\x1b[42m Bash \x1b[0m \x1b[90m(${toggleShortcut}: Claude)\x1b[0m`;
 
 			// Display in status line at top of terminal
 			stdout.write(`\x1b[s\x1b[1;1H${indicator}\x1b[u`);
@@ -290,7 +291,7 @@ const Session: React.FC<SessionProps> = ({
 				return;
 			}
 
-			// Check for mode toggle shortcut (Ctrl+T)
+			// Check for mode toggle shortcut
 			const toggleModeCode = shortcutManager.getShortcutCode(
 				shortcuts.toggleMode,
 			);

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -314,4 +314,88 @@ describe('SessionManager', () => {
 			expect(sessionManager.getSession('/test/worktree')).toBeUndefined();
 		});
 	});
+
+	describe('Bash Session Restoration Events', () => {
+		it('should emit bashSessionRestore event when bash session becomes active with history', async () => {
+			// Setup mock configuration
+			vi.mocked(configurationManager.getCommandConfig).mockReturnValue({
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			// Create session and set up bash mode with history
+			const session = await sessionManager.createSession('/test/worktree');
+			session.currentMode = 'bash';
+			session.bashHistory = [
+				Buffer.from('$ ls\n'),
+				Buffer.from('file1.txt file2.txt\n'),
+				Buffer.from('$ pwd\n')
+			];
+
+			// Set up event listener spy
+			const bashRestoreEventSpy = vi.fn();
+			sessionManager.on('bashSessionRestore', bashRestoreEventSpy);
+
+			// Test: Activate session in bash mode
+			sessionManager.setSessionActive('/test/worktree', true);
+
+			// Verify: bashSessionRestore event is emitted
+			expect(bashRestoreEventSpy).toHaveBeenCalledWith(session);
+			expect(bashRestoreEventSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should emit sessionRestore event when claude session becomes active with history', async () => {
+			// Setup mock configuration
+			vi.mocked(configurationManager.getCommandConfig).mockReturnValue({
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			// Create session and set up claude mode with history
+			const session = await sessionManager.createSession('/test/worktree');
+			session.currentMode = 'claude';
+			session.outputHistory = [
+				Buffer.from('Claude response 1\n'),
+				Buffer.from('Claude response 2\n')
+			];
+
+			// Set up event listener spy
+			const claudeRestoreEventSpy = vi.fn();
+			sessionManager.on('sessionRestore', claudeRestoreEventSpy);
+
+			// Test: Activate session in claude mode
+			sessionManager.setSessionActive('/test/worktree', true);
+
+			// Verify: sessionRestore event is emitted
+			expect(claudeRestoreEventSpy).toHaveBeenCalledWith(session);
+			expect(claudeRestoreEventSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not emit restore events when session has no history', async () => {
+			// Setup mock configuration
+			vi.mocked(configurationManager.getCommandConfig).mockReturnValue({
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			// Create session with empty histories
+			const session = await sessionManager.createSession('/test/worktree');
+			session.currentMode = 'bash';
+			session.bashHistory = [];
+			session.outputHistory = [];
+
+			// Set up event listener spies
+			const bashRestoreEventSpy = vi.fn();
+			const claudeRestoreEventSpy = vi.fn();
+			sessionManager.on('bashSessionRestore', bashRestoreEventSpy);
+			sessionManager.on('sessionRestore', claudeRestoreEventSpy);
+
+			// Test: Activate session with empty histories
+			sessionManager.setSessionActive('/test/worktree', true);
+
+			// Verify: No restore events are emitted
+			expect(bashRestoreEventSpy).not.toHaveBeenCalled();
+			expect(claudeRestoreEventSpy).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -113,6 +113,11 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			terminal,
 			isPrimaryCommand: true,
 			commandConfig,
+
+			// Dual-mode properties initialization
+			currentMode: 'claude', // Always start in Claude mode
+			bashHistory: [],
+			bashState: 'idle',
 		};
 
 		// Set up persistent background data handler for state detection
@@ -250,6 +255,16 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			} catch (_error) {
 				// Process might already be dead
 			}
+
+			// Clean up bash PTY if it exists
+			if (session.bashProcess) {
+				try {
+					session.bashProcess.kill();
+				} catch (_error) {
+					// Bash process might already be dead
+				}
+			}
+
 			// Clean up any pending timer
 			const timer = this.busyTimers.get(worktreePath);
 			if (timer) {

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -236,14 +236,16 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		if (session) {
 			session.isActive = active;
 
-			// If becoming active, emit a restore event with the output history
-			// Only restore Claude history if in Claude mode (dual-mode compatibility)
-			if (
-				active &&
-				session.outputHistory.length > 0 &&
-				session.currentMode === 'claude'
-			) {
-				this.emit('sessionRestore', session);
+			// If becoming active, emit a restore event with the appropriate history
+			if (active) {
+				// Restore Claude history if in Claude mode and has history
+				if (session.outputHistory.length > 0 && session.currentMode === 'claude') {
+					this.emit('sessionRestore', session);
+				}
+				// Restore bash history if in bash mode and has history
+				else if (session.bashHistory.length > 0 && session.currentMode === 'bash') {
+					this.emit('bashSessionRestore', session);
+				}
 			}
 		}
 	}

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -237,7 +237,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			session.isActive = active;
 
 			// If becoming active, emit a restore event with the output history
-			if (active && session.outputHistory.length > 0) {
+			// Only restore Claude history if in Claude mode (dual-mode compatibility)
+			if (
+				active &&
+				session.outputHistory.length > 0 &&
+				session.currentMode === 'claude'
+			) {
 				this.emit('sessionRestore', session);
 			}
 		}

--- a/src/services/shortcutManager.ts
+++ b/src/services/shortcutManager.ts
@@ -66,6 +66,9 @@ export class ShortcutManager {
 				currentShortcuts.returnToMenu,
 			cancel:
 				this.validateShortcut(shortcuts.cancel) || currentShortcuts.cancel,
+			toggleMode:
+				this.validateShortcut(shortcuts.toggleMode) ||
+				currentShortcuts.toggleMode,
 		};
 
 		configurationManager.setShortcuts(validated);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export type Terminal = InstanceType<typeof pkg.Terminal>;
 
 export type SessionState = 'idle' | 'busy' | 'waiting_input';
 
+export type TerminalMode = 'claude' | 'bash';
+
 export interface Worktree {
 	path: string;
 	branch: string;
@@ -18,13 +20,20 @@ export interface Session {
 	process: IPty;
 	state: SessionState;
 	output: string[]; // Recent output for state detection
-	outputHistory: Buffer[]; // Full output history as buffers
+	outputHistory: Buffer[]; // Full output history as buffers (Claude mode)
 	lastActivity: Date;
 	isActive: boolean;
 	terminal: Terminal; // Virtual terminal for state detection (xterm Terminal instance)
 	stateCheckInterval?: NodeJS.Timeout; // Interval for checking terminal state
 	isPrimaryCommand?: boolean; // Track if process was started with main command args
 	commandConfig?: CommandConfig; // Store command config for fallback
+
+	// Dual-mode properties
+	bashProcess?: IPty; // Bash PTY instance (created on-demand)
+	currentMode: TerminalMode; // Current active mode
+	bashHistory: Buffer[]; // Bash mode history for restoration
+	bashState: 'idle' | 'running'; // Simple state tracking for bash
+	bashWorkingDirectory?: string; // Bash PWD tracking
 }
 
 export interface SessionManager {
@@ -45,11 +54,13 @@ export interface ShortcutKey {
 export interface ShortcutConfig {
 	returnToMenu: ShortcutKey;
 	cancel: ShortcutKey;
+	toggleMode: ShortcutKey; // Toggle between Claude and Bash modes
 }
 
 export const DEFAULT_SHORTCUTS: ShortcutConfig = {
 	returnToMenu: {ctrl: true, key: 'e'},
 	cancel: {key: 'escape'},
+	toggleMode: {ctrl: true, key: 't'},
 };
 
 export interface StatusHook {


### PR DESCRIPTION
## Summary
Adds dual-mode terminal functionality allowing users to toggle between Claude Code and Bash sessions using Ctrl+T within the same worktree.

## Key Features
- **Ctrl+T toggle**: Switch between Claude and Bash modes seamlessly
- **Independent sessions**: Separate PTY processes with isolated history
- **Session restoration**: History preserved when switching modes/worktrees
- **Configurable shortcuts**: Toggle shortcut customizable via existing UI

## Use Cases
- Generate code with Claude, then test in bash
- Perform git operations while maintaining Claude context
- File management alongside AI assistance

## Testing
- 58/58 tests passing
- 3 new unit tests for bash session restoration

Fully backward compatible - existing workflows unchanged.