### PR TITLE
fix: detect background tasks shown as "N local agents"

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.1",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.1",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.1",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.5.1",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.5.1",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.2",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.2",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.2",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.5.2",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.5.2",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DTCAPQHqwnBEuJwNhKDJMezqRQF/f9LJS48icqu6GPojuTSXcINDe099uvwD3tj1dHVcP4OAAbldOg2o5nCj0w=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LtaApUeS8uRFnqIiG9MUMdxG1mrEjjPbe3gtDyknVt0r6mmaOPY/ke+otOrdmR8jPup3gU5zkMXrh9wrpQCNeA=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-DNcNNrOofRGYiz/bzFjxeBEdYrLgFIYsH5Jquzf23neI+TRKBTNTLj468pe57cK+pcouDhx/tPC3ZghC1Q858w=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-pJ1FLtnpEKaqlaJb12/vTAG0LmtlDg+bAQvdCLZBuZuPMa2Wu7z6phtGk//FRgv+dHnw24RYMN9LmKi8+1ukvA=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-sUk8hcB45X6UrtiD+Jcz2YC6Qmk7gj3ZZEfYWBXW6Hhq4gVjIVTdKgDUjMIS8lmnNY8S3Wl6Qxxh5/JUPsjPbg=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cdeppi0qKHrkuv9JwcnhPFvDL/KieELIVeyrjPZNMW7WuuMZiQhuLdPnLSa8NPfjXCAxIb48cP6J6VaiTuFITQ=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-AzJrCG0hbSCE7QC94QyOjQ6K9W4LpZ80AivtOnSpUXe7CwU1Pw2tRHRYDNr9SMAVnTLlbeLpFyNZ2KZOMZ6n4g=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-qydjU+Rfsk99G5MCHrYmfw33pk13zNVJIppTXW5gL5Hn49rCktJqeL7ycDitxzSwmN9Fn3D1jO9UOwWqLU1Jbw=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QfhrnV9xfE5eoWKaZqvo8wCW6PpcF4e8acaF6o2mzZzXXpEdVp0CcuzEs7u6F1WN5na/Lfvs1dh3KkkXsTpo0g=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9TxWQj+WMJhteA9Vt1A/dB6ALLvg7e9h4HJpawRjnVAdb8hovgHtAcYW7olNIYCZIePZ3vL628bMpfsP8D+D0Q=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.4",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.4",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.4",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.5.4",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.5.4",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.6.0",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.6.0",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.6.0",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.6.0",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.6.0",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q4NZ182ffsbKE4l+7kaY8IY+Es0odE3B13UShtr/BEftV2h1b/MPlp3cRsm18CKPGtSMgcSmbg7uOPFH1dd5Gw=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.6.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YaPxBQxoBw87hAwNXZydTma9l3tXvCtuHU8Owi/doSDdI5FFuolL9k8prjYx8iQnfcjJq8L2wrx5gAbekbYREA=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-g2iMrqBaQwzKpJqtn1qhtHuu9BAL+7A0/0w1b1amiENabbANJUjz4wqx0OwYRbZRDP/9U8qDfMCJudemIqEthA=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.6.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-yCzAaKoY/31PeTJkYXXr/KaUM6XuguHq6tBlRb/JeKtgBP8YE0a6tLzRrJtAB8LukSa6RlPCR51IGV8Qd0hGzA=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-uSZs/anx8dcmfPCUbogqfBqrkFffQtrsDdlfe0P8R99EDHoGNJETtxk0HOPkYmnk1MQvKq3Y+BrWUkH612205A=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lJGnuJQ1uB92H2MEidkn0h/p6mGnlFee6u295GswbyC9IDIvOrS0ozdkPaN+wxeg8TBxwAWXOeVlJkrDKUJSYA=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-F5bywGJxwv394G75GK4TdwLj+g+2AyVYLBkUdsudKVTmTmuvXf+IO5ZB2kAwEik9erow2SWGOTkfAecrIqciLg=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-EZbAq+Krp17xhnF2o/SczyeH4TuhVF7zGH4bGJA2B3LETx0w9M1wFrBrT8191GSMR1Oo33R3V9C/kj3s+xtQOw=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-3njdafX8sCaofOFcXc12Vb2gtBDfMjfJjJBjIX4YuWeP6GWqJBZVPNeu6Hy1VICkSFgqu8dtYHjMPw6MZJFZ6A=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q9VybuDoNq5faucZipRn2/W7Gvry05DzgZxOB7cW7hkiUjpvS53lkNuVwF0OxLaZ3iK4Odd77PuuFqIEhtatPA=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.6.1",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.6.1",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.6.1",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.6.1",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.6.1",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.6.3",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.6.3",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.6.3",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.6.3",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.6.3",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.6.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oeWysJZTBNEUMTAAm0GHUWQ1NRQ9UviJzSoP0f8SiVpjofAMcTYXUw4LQeZtlMaQzAn+fv0LzeXClKLtieeTrQ=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.6.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wkRggWrGJllNF1ihPn9jhFzlrwNSTCpLet+xAVfb1n/oEemkTkIh8tkCwo89fCyOJtXNaDnf39mYExGPMETBtQ=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.6.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-tJ66rXMz6xR4MEL4qMnot6adVpOHKilxyVUCiYIChiDQdvSyHc9jQZ7sLwJhg29dJMF+ZASPG7RlpiKz8oOK1A=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.6.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-VdyBS/1sTXbvjWHijWUpzvM9e587QVHu3S8taQjd5HA8wmV/pw/53pDPos35HhLoTPjOwueqLqIYGAcwQKhOuA=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-npfcTbhEGFsoHf+5A1w9WHvm1hiIfFBgo63nV/7zCCOY1yPkI0ZvpPhH4OqUNZVNvXswZIkspJQ9FyirDN1KSg=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.6.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-GEpapzZhRl7GfJIGjq45D0iLS4GyWDTmLxCdEK8lkES919QJO3fQPK6k3JvYevDKh9zbuDtQ6nTV5HHCBQRr2g=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-I8Dye6tY535/FDXJaRFLo4mg1k7Ol0vICxgl1Sj+UaTXfuL5Ok/n/LUnaRHsX6zrEzU1a7V4Iii5KDxoTmQuHQ=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.6.3", "", { "os": "linux", "cpu": "x64" }, "sha512-6OVT2b6RlEayHUlK6FHBtxNCUGRDcU/9UNJbvsYxM3uZzaoZcQZLyAX98QJRlC+s8+HMH6p3r7TxWAbsX7A0Dw=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.6.1", "", { "os": "win32", "cpu": "x64" }, "sha512-MAlRAmL4JgRBbyTqfS+MeBI1zF3LhBNxUOKME4fWLH/lcBxhJ7gnqgZZbIAfQ+DMPf+Dsl4iQUrBplqXC0bedg=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.6.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Jpu4guFbtbamRM3E2MNhAOXxLGw7YgoZf8gtpAggQlkmAEiVyzzVCyDbQjQS496Y7CtaCNXFCAHCwvLGNpbTOg=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.4.0",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.4.0",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.4.0",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.4.0",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.4.0",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.0",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.0",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.0",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.5.0",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.5.0",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SYAGwJcVX+0CIcCwh1HS+h5Toycsa6JEk3Xj4dxcr4TQchczkMvQkUICcQ0q9kqywHKP6dr9raKSuuFrwbf7nA=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C09sdjsz3RD0sKx6q9NPd4JmcgnttgbAcB4UybE/6gcbmhTQKvIM7+aCDq2VRTKPTpFwNQNkv3wRKp28FodM0Q=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-cgDdNy4lh+UeZPtxd3/j4X7TJdttCg1NN+q4slL5IN1O0wu6sgVQ1KLOYQbttvsbmVXhqkOaOGb8gBcZF8WGog=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-TtU80n8P6xxGRMLvqi2BloMtbipyxpx3UJgHis+ubyRFSJwOWbypkTAq2mSgSWqY5kP9lba4U/t/XAASOOw5yg=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-dv0OmcJt7mKrKh5AB4l0jIbrqAzBrdvfwbVVaock+Ef3E6CBBoys/2Z4GMMpMu4QcZKcTAvZWEzFWNnBJoRO5Q=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-921XZrGQLz+jLlino2PJEsQ2CsJbSFKXMxBV4/W7MCRc31VcwSkm3oJadOAT7+V/P5ulxPKF2FmxkflcDdquHA=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-LLN/3UsXmWKzTAtayOHvGDX66FFVOkcA2cfqkS/0fyJWirEws/RQOIRq1ilOOwR9+iGzKmVyM4UTmY9HnqlH2w=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2EZXrI2Rh7IFepbII95uXgq6ta9+REgOUMQNjoCVgBSbytHPUvo8MtPlBS7n/YJ1JBHdOV+zvFa2jDkOCTLyeg=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-3G4GuADqnDNRuGY1P6RB/lr1tu+pkOI7DNw87mBc0sXRET0IaMmBVD3PERH9muWUU/kg5xnCH27NPF+34PIDgQ=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QFLbwzaNOJRdQnyRIkZWy8Cr8czhAjTjhv5I/atCnFq3I71wsWBel/Hv4lG9QkND/F4beWS7xvqKgEcvmCG9rQ=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.3",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.3",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.3",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.5.3",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.5.3",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.4",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.4",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.4",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.5.4",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.5.4",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rgv6lMJtJCKF9Dtsd4ntMzfN3a38zGNdShtXw7TeDKm54U7iGjSRsJTBh659h+mgYQgf2Zp4ebNdcfhC2FR0UQ=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q4NZ182ffsbKE4l+7kaY8IY+Es0odE3B13UShtr/BEftV2h1b/MPlp3cRsm18CKPGtSMgcSmbg7uOPFH1dd5Gw=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-GAiAgTykeRvWoVuuiEDhboIp8hvQs/edIEX6Xw2a5dzCITFmtn35sT2fLNvNMW9imBP/pdR5yR6/9m099lPGoQ=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-g2iMrqBaQwzKpJqtn1qhtHuu9BAL+7A0/0w1b1amiENabbANJUjz4wqx0OwYRbZRDP/9U8qDfMCJudemIqEthA=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-uTFHLLTni0EyBmu9Bvzw5D9L/Ih6BadWxO3POzM1sVg5qR/S3rMtlg/LeGrPcCDiArGW06lrB0MbE/zdKyG7SQ=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-uSZs/anx8dcmfPCUbogqfBqrkFffQtrsDdlfe0P8R99EDHoGNJETtxk0HOPkYmnk1MQvKq3Y+BrWUkH612205A=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3YHEFjSSWCpP2/PB9ZFazyCc3G1WPa54uhAH2HW6GXx5WGaaF0nckoy721tf+x0uVchK42/84TbrekH3Shy8Zg=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-F5bywGJxwv394G75GK4TdwLj+g+2AyVYLBkUdsudKVTmTmuvXf+IO5ZB2kAwEik9erow2SWGOTkfAecrIqciLg=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-TetIBrPs4bZhcPkRLtk+DfCO8vqdMMYmxLL+ZkZdyO0If2n6nr86oEUMjSSphcIWaWTUKVHdXFHxyUvQL1UHSA=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-3njdafX8sCaofOFcXc12Vb2gtBDfMjfJjJBjIX4YuWeP6GWqJBZVPNeu6Hy1VICkSFgqu8dtYHjMPw6MZJFZ6A=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.6.0",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.6.0",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.6.0",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.6.0",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.6.0",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.6.1",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.6.1",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.6.1",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.6.1",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.6.1",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.6.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YaPxBQxoBw87hAwNXZydTma9l3tXvCtuHU8Owi/doSDdI5FFuolL9k8prjYx8iQnfcjJq8L2wrx5gAbekbYREA=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.6.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oeWysJZTBNEUMTAAm0GHUWQ1NRQ9UviJzSoP0f8SiVpjofAMcTYXUw4LQeZtlMaQzAn+fv0LzeXClKLtieeTrQ=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.6.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-yCzAaKoY/31PeTJkYXXr/KaUM6XuguHq6tBlRb/JeKtgBP8YE0a6tLzRrJtAB8LukSa6RlPCR51IGV8Qd0hGzA=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.6.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-tJ66rXMz6xR4MEL4qMnot6adVpOHKilxyVUCiYIChiDQdvSyHc9jQZ7sLwJhg29dJMF+ZASPG7RlpiKz8oOK1A=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lJGnuJQ1uB92H2MEidkn0h/p6mGnlFee6u295GswbyC9IDIvOrS0ozdkPaN+wxeg8TBxwAWXOeVlJkrDKUJSYA=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-npfcTbhEGFsoHf+5A1w9WHvm1hiIfFBgo63nV/7zCCOY1yPkI0ZvpPhH4OqUNZVNvXswZIkspJQ9FyirDN1KSg=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-EZbAq+Krp17xhnF2o/SczyeH4TuhVF7zGH4bGJA2B3LETx0w9M1wFrBrT8191GSMR1Oo33R3V9C/kj3s+xtQOw=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-I8Dye6tY535/FDXJaRFLo4mg1k7Ol0vICxgl1Sj+UaTXfuL5Ok/n/LUnaRHsX6zrEzU1a7V4Iii5KDxoTmQuHQ=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q9VybuDoNq5faucZipRn2/W7Gvry05DzgZxOB7cW7hkiUjpvS53lkNuVwF0OxLaZ3iK4Odd77PuuFqIEhtatPA=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.6.1", "", { "os": "win32", "cpu": "x64" }, "sha512-MAlRAmL4JgRBbyTqfS+MeBI1zF3LhBNxUOKME4fWLH/lcBxhJ7gnqgZZbIAfQ+DMPf+Dsl4iQUrBplqXC0bedg=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,20 +7,20 @@
       "dependencies": {
         "@xterm/headless": "^6.0.0",
         "effect": "^3.18.2",
-        "ink": "5.2.1",
+        "ink": "^6.6.0",
         "ink-select-input": "^6.0.0",
         "ink-text-input": "^6.0.0",
         "meow": "^14.0.0",
-        "react": "18.3.1",
-        "react-devtools-core": "^7.0.1",
-        "react-dom": "18.3.1",
+        "react": "^19.2.3",
+        "react-devtools-core": "^6.1.2",
+        "react-dom": "^19.2.3",
         "strip-ansi": "^7.1.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
-        "@sindresorhus/tsconfig": "^3.0.1",
+        "@sindresorhus/tsconfig": "^8.1.0",
         "@types/bun": "latest",
-        "@types/react": "^18.0.32",
+        "@types/react": "^19.2.9",
         "@typescript-eslint/eslint-plugin": "^8.33.1",
         "@typescript-eslint/parser": "^8.33.1",
         "@vdemedes/prettier-config": "^2.0.1",
@@ -36,16 +36,16 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.0",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.0",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.0",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.5.0",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.5.0",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.1",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.1",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.1",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.5.1",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.5.1",
       },
     },
   },
   "packages": {
-    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-jsElTJ0sQ4wHRz+C45tfect76BwbTbgkgKByOzpCN9xG61N5V6u/glvg1CsNJhq2xJIFpKHSwG3D2wPPuEYOrQ=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C09sdjsz3RD0sKx6q9NPd4JmcgnttgbAcB4UybE/6gcbmhTQKvIM7+aCDq2VRTKPTpFwNQNkv3wRKp28FodM0Q=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DTCAPQHqwnBEuJwNhKDJMezqRQF/f9LJS48icqu6GPojuTSXcINDe099uvwD3tj1dHVcP4OAAbldOg2o5nCj0w=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-TtU80n8P6xxGRMLvqi2BloMtbipyxpx3UJgHis+ubyRFSJwOWbypkTAq2mSgSWqY5kP9lba4U/t/XAASOOw5yg=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-DNcNNrOofRGYiz/bzFjxeBEdYrLgFIYsH5Jquzf23neI+TRKBTNTLj468pe57cK+pcouDhx/tPC3ZghC1Q858w=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-921XZrGQLz+jLlino2PJEsQ2CsJbSFKXMxBV4/W7MCRc31VcwSkm3oJadOAT7+V/P5ulxPKF2FmxkflcDdquHA=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-sUk8hcB45X6UrtiD+Jcz2YC6Qmk7gj3ZZEfYWBXW6Hhq4gVjIVTdKgDUjMIS8lmnNY8S3Wl6Qxxh5/JUPsjPbg=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2EZXrI2Rh7IFepbII95uXgq6ta9+REgOUMQNjoCVgBSbytHPUvo8MtPlBS7n/YJ1JBHdOV+zvFa2jDkOCTLyeg=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-AzJrCG0hbSCE7QC94QyOjQ6K9W4LpZ80AivtOnSpUXe7CwU1Pw2tRHRYDNr9SMAVnTLlbeLpFyNZ2KZOMZ6n4g=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QFLbwzaNOJRdQnyRIkZWy8Cr8czhAjTjhv5I/atCnFq3I71wsWBel/Hv4lG9QkND/F4beWS7xvqKgEcvmCG9rQ=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QfhrnV9xfE5eoWKaZqvo8wCW6PpcF4e8acaF6o2mzZzXXpEdVp0CcuzEs7u6F1WN5na/Lfvs1dh3KkkXsTpo0g=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
@@ -183,7 +183,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg=="],
 
-    "@sindresorhus/tsconfig": ["@sindresorhus/tsconfig@3.0.1", "", {}, "sha512-0/gtPNTY3++0J2BZM5nHHULg0BIMw886gqdn8vWN+Av6bgF5ZU2qIcHubAn+Z9KNvJhO8WFE+9kDOU3n6OcKtA=="],
+    "@sindresorhus/tsconfig": ["@sindresorhus/tsconfig@8.1.0", "", {}, "sha512-MggpguA4jNdtyoUy2Hs54nb4lP4rbhH34CsOiFId1q6fmFPnipqeo70ZRkjp5p4Z7wdyspALtSAcKaxL2/3waQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -199,9 +199,7 @@
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
-
-    "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
+    "@types/react": ["@types/react@19.2.9", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.50.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.50.1", "@typescript-eslint/type-utils": "8.50.1", "@typescript-eslint/utils": "8.50.1", "@typescript-eslint/visitor-keys": "8.50.1", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.50.1", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw=="],
 
@@ -299,7 +297,7 @@
 
     "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
-    "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+    "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
 
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
@@ -463,7 +461,7 @@
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
-    "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
+    "ink": ["ink@6.6.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.1", "ansi-escapes": "^7.2.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^8.1.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": "^6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-QDt6FgJxgmSxAelcOvOHUvFxbIUjVpCH5bx+Slvc5m7IEcpGt3dYwbz/L+oRnqEGeRvwy1tineKK4ect3nW1vQ=="],
 
     "ink-select-input": ["ink-select-input@6.2.0", "", { "dependencies": { "figures": "^6.1.0", "to-rotated": "^1.0.0" }, "peerDependencies": { "ink": ">=5.0.0", "react": ">=18.0.0" } }, "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ=="],
 
@@ -493,13 +491,13 @@
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
-    "is-in-ci": ["is-in-ci@1.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
@@ -629,15 +627,15 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
-    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+    "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
-    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+    "react-devtools-core": ["react-devtools-core@6.1.5", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA=="],
 
-    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+    "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "react-reconciler": ["react-reconciler@0.29.2", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg=="],
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -657,7 +655,7 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
-    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -697,7 +695,7 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
 
@@ -787,17 +785,17 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
-
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.2",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.2",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.2",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.5.2",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.5.2",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.5.3",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.5.3",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.5.3",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.5.3",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.5.3",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LtaApUeS8uRFnqIiG9MUMdxG1mrEjjPbe3gtDyknVt0r6mmaOPY/ke+otOrdmR8jPup3gU5zkMXrh9wrpQCNeA=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.5.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rgv6lMJtJCKF9Dtsd4ntMzfN3a38zGNdShtXw7TeDKm54U7iGjSRsJTBh659h+mgYQgf2Zp4ebNdcfhC2FR0UQ=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-pJ1FLtnpEKaqlaJb12/vTAG0LmtlDg+bAQvdCLZBuZuPMa2Wu7z6phtGk//FRgv+dHnw24RYMN9LmKi8+1ukvA=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.5.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-GAiAgTykeRvWoVuuiEDhboIp8hvQs/edIEX6Xw2a5dzCITFmtn35sT2fLNvNMW9imBP/pdR5yR6/9m099lPGoQ=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cdeppi0qKHrkuv9JwcnhPFvDL/KieELIVeyrjPZNMW7WuuMZiQhuLdPnLSa8NPfjXCAxIb48cP6J6VaiTuFITQ=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-uTFHLLTni0EyBmu9Bvzw5D9L/Ih6BadWxO3POzM1sVg5qR/S3rMtlg/LeGrPcCDiArGW06lrB0MbE/zdKyG7SQ=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-qydjU+Rfsk99G5MCHrYmfw33pk13zNVJIppTXW5gL5Hn49rCktJqeL7ycDitxzSwmN9Fn3D1jO9UOwWqLU1Jbw=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3YHEFjSSWCpP2/PB9ZFazyCc3G1WPa54uhAH2HW6GXx5WGaaF0nckoy721tf+x0uVchK42/84TbrekH3Shy8Zg=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9TxWQj+WMJhteA9Vt1A/dB6ALLvg7e9h4HJpawRjnVAdb8hovgHtAcYW7olNIYCZIePZ3vL628bMpfsP8D+D0Q=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-TetIBrPs4bZhcPkRLtk+DfCO8vqdMMYmxLL+ZkZdyO0If2n6nr86oEUMjSSphcIWaWTUKVHdXFHxyUvQL1UHSA=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.5.4",
+	"version": "3.6.0",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.6.1",
+	"version": "3.6.3",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.5.3",
+	"version": "3.5.4",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
-	"version": "3.5.1",
+	"version": "3.5.2",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.5.4",
+	"version": "3.6.0",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.5.1",
+	"version": "3.5.2",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.6.1",
+	"version": "3.6.3",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.5.3",
+	"version": "3.5.4",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-darwin-x64",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.5.4",
+	"version": "3.6.0",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.6.1",
+	"version": "3.6.3",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.5.3",
+	"version": "3.5.4",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-arm64",
-	"version": "3.5.1",
+	"version": "3.5.2",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.5.1",
+	"version": "3.5.2",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.6.1",
+	"version": "3.6.3",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.5.4",
+	"version": "3.6.0",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-linux-x64",
-	"version": "3.5.3",
+	"version": "3.5.4",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.5.4",
+	"version": "3.6.0",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.6.1",
+	"version": "3.6.3",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.5.1",
+	"version": "3.5.2",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.5.3",
+	"version": "3.5.4",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kodaikabasawa/ccmanager-win32-x64",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"build:binary:native": "bun run scripts/build-binaries.ts --target=native",
 		"build:binary:all": "bun run scripts/build-binaries.ts --target=all",
 		"dev": "bun run tsc --watch",
-		"start": "bun dist/cli.js",
+		"start": "bun --no-env-file dist/cli.js",
 		"test": "vitest --run",
 		"lint": "bun run eslint src",
 		"lint:fix": "bun run eslint src --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.2",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.2",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.2",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.5.2",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.5.2"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.3",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.3",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.3",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.5.3",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.5.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.0",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.0",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.0",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.5.0",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.5.0"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.1",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.1",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.1",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.5.1",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.5.1"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.5.4",
+	"version": "3.6.0",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.4",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.4",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.4",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.5.4",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.5.4"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.0",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.0",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.0",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.6.0",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.6.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.6.1",
+	"version": "3.6.3",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.1",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.1",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.1",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.6.1",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.6.1"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.3",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.3",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.3",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.6.3",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.6.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.5.3",
+	"version": "3.5.4",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.3",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.3",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.3",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.5.3",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.5.3"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.4",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.4",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.4",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.5.4",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.5.4"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.5.1",
+	"version": "3.5.2",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.1",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.1",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.1",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.5.1",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.5.1"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.5.2",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.5.2",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.5.2",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.5.2",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.5.2"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",
-		"@sindresorhus/tsconfig": "^3.0.1",
+		"@sindresorhus/tsconfig": "^8.1.0",
 		"@types/bun": "latest",
-		"@types/react": "^18.0.32",
+		"@types/react": "^19.2.9",
 		"@typescript-eslint/eslint-plugin": "^8.33.1",
 		"@typescript-eslint/parser": "^8.33.1",
 		"@vdemedes/prettier-config": "^2.0.1",
@@ -70,13 +70,13 @@
 	"dependencies": {
 		"@xterm/headless": "^6.0.0",
 		"effect": "^3.18.2",
-		"ink": "5.2.1",
+		"ink": "^6.6.0",
 		"ink-select-input": "^6.0.0",
 		"ink-text-input": "^6.0.0",
 		"meow": "^14.0.0",
-		"react": "18.3.1",
-		"react-devtools-core": "^7.0.1",
-		"react-dom": "18.3.1",
+		"react": "^19.2.3",
+		"react-devtools-core": "^6.1.2",
+		"react-dom": "^19.2.3",
 		"strip-ansi": "^7.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.3",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.3",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.3",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.6.3",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.6.3"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.4",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.4",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.4",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.6.4",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.6.4"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ccmanager",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "TUI application for managing multiple Claude Code sessions across Git worktrees",
 	"license": "MIT",
 	"author": "Kodai Kabasawa",
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.0",
-		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.0",
-		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.0",
-		"@kodaikabasawa/ccmanager-linux-x64": "3.6.0",
-		"@kodaikabasawa/ccmanager-win32-x64": "3.6.0"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.6.1",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.6.1",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.6.1",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.6.1",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.6.1"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -52,7 +52,7 @@ async function buildBinary(target: (typeof TARGETS)[number]) {
 	mkdirSync(outputDir, { recursive: true });
 
 	try {
-		await $`bun build ${ENTRY_POINT} --compile --target=${target.bunTarget} --outfile=${outputPath} --define CCMANAGER_VERSION='"${VERSION}"'`;
+		await $`bun build ${ENTRY_POINT} --compile --target=${target.bunTarget} --outfile=${outputPath} --define CCMANAGER_VERSION='"${VERSION}"' --no-compile-autoload-dotenv --no-compile-autoload-bunfig`;
 		console.log(`  -> Created ${outputPath}`);
 		return true;
 	} catch (error) {

--- a/scripts/setup-submodule-test.sh
+++ b/scripts/setup-submodule-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Script to reproduce GitHub issue #189
+# Creates a project structure with submodules to test CCManager's project recognition
+#
+# Usage: ./setup-submodule-test.sh <parent-directory>
+# Example: ./setup-submodule-test.sh /tmp/ccmanager-test
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <parent-directory>"
+    echo "Example: $0 /tmp/ccmanager-test"
+    exit 1
+fi
+
+PARENT_DIR="$1"
+ROOT_PROJECT="$PARENT_DIR/root-project"
+
+# Clean up if exists
+if [ -d "$PARENT_DIR" ]; then
+    echo "Removing existing directory: $PARENT_DIR"
+    rm -rf "$PARENT_DIR"
+fi
+
+echo "Creating test directory structure at: $PARENT_DIR"
+
+# Create parent directory
+mkdir -p "$PARENT_DIR"
+
+# Create submodule repositories (these will be added as submodules)
+echo "Creating submodule source repositories..."
+
+# Create submodule-1 source repo
+mkdir -p "$PARENT_DIR/submodule-1-source"
+cd "$PARENT_DIR/submodule-1-source"
+git init
+echo "# Submodule 1" > README.md
+git add README.md
+git commit -m "Initial commit for submodule-1"
+
+# Create submodule-2 source repo
+mkdir -p "$PARENT_DIR/submodule-2-source"
+cd "$PARENT_DIR/submodule-2-source"
+git init
+echo "# Submodule 2" > README.md
+git add README.md
+git commit -m "Initial commit for submodule-2"
+
+# Create root project
+echo "Creating root project..."
+mkdir -p "$ROOT_PROJECT"
+cd "$ROOT_PROJECT"
+git init
+echo "# Root Project" > README.md
+git add README.md
+git commit -m "Initial commit for root-project"
+
+# Create modules directory and add submodules
+echo "Adding submodules to modules/ directory..."
+mkdir -p modules
+
+# Add submodules
+git submodule add "$PARENT_DIR/submodule-1-source" modules/submodule-1
+git submodule add "$PARENT_DIR/submodule-2-source" modules/submodule-2
+git commit -m "Add submodules"
+
+echo ""
+echo "======================================"
+echo "Test environment created successfully!"
+echo "======================================"
+echo ""
+echo "Directory structure:"
+echo "$PARENT_DIR/"
+echo "├── submodule-1-source/  (source repo for submodule-1)"
+echo "├── submodule-2-source/  (source repo for submodule-2)"
+echo "└── root-project/"
+echo "    └── modules/"
+echo "        ├── submodule-1/  (git submodule)"
+echo "        └── submodule-2/  (git submodule)"
+echo ""
+echo "To reproduce issue #189:"
+echo "  cd $ROOT_PROJECT/modules/submodule-1"
+echo "  npx ccmanager"
+echo ""
+echo "Expected: Project should be recognized as 'submodule-1'"
+echo "Actual (bug): Project is recognized as 'modules'"

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -90,6 +90,7 @@ const devcontainerConfig =
 const appProps = {
 	...(devcontainerConfig ? {devcontainerConfig} : {}),
 	multiProject: cli.flags.multiProject,
+	version,
 };
 
 const app = render(<App {...appProps} />);

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -247,7 +247,7 @@ afterEach(() => {
 
 describe('App component view state', () => {
 	it('renders the menu view by default', async () => {
-		const {lastFrame, unmount} = render(<App />);
+		const {lastFrame, unmount} = render(<App version="test" />);
 		await flush(40);
 
 		expect(lastFrame()).toContain('Menu View');
@@ -259,7 +259,7 @@ describe('App component view state', () => {
 		const original = process.env[ENV_VARS.MULTI_PROJECT_ROOT];
 		process.env[ENV_VARS.MULTI_PROJECT_ROOT] = '/tmp/projects';
 
-		const {lastFrame, unmount} = render(<App multiProject />);
+		const {lastFrame, unmount} = render(<App multiProject version="test" />);
 		await flush();
 
 		expect(lastFrame()).toContain('Project List View');
@@ -286,7 +286,7 @@ describe('App component loading state machine', () => {
 			}),
 		);
 
-		const {lastFrame, unmount} = render(<App />);
+		const {lastFrame, unmount} = render(<App version="test" />);
 		await waitForCondition(() => Boolean(menuProps));
 
 		const menu = menuProps!;
@@ -333,7 +333,7 @@ describe('App component loading state machine', () => {
 			}),
 		);
 
-		const {lastFrame, unmount} = render(<App />);
+		const {lastFrame, unmount} = render(<App version="test" />);
 		await waitForCondition(() => Boolean(menuProps));
 
 		const menu = menuProps!;
@@ -370,6 +370,7 @@ describe('App component loading state machine', () => {
 
 		const {lastFrame, unmount} = render(
 			<App
+				version="test"
 				devcontainerConfig={
 					{
 						upCommand: 'podman up',

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -48,9 +48,14 @@ type View =
 interface AppProps {
 	devcontainerConfig?: DevcontainerConfig;
 	multiProject?: boolean;
+	version: string;
 }
 
-const App: React.FC<AppProps> = ({devcontainerConfig, multiProject}) => {
+const App: React.FC<AppProps> = ({
+	devcontainerConfig,
+	multiProject,
+	version,
+}) => {
 	const {exit} = useApp();
 	const [view, setView] = useState<View>(
 		multiProject ? 'project-list' : 'menu',
@@ -592,6 +597,7 @@ const App: React.FC<AppProps> = ({devcontainerConfig, multiProject}) => {
 				onDismissError={() => setError(null)}
 				projectName={selectedProject?.name}
 				multiProject={multiProject}
+				version={version}
 			/>
 		);
 	}

--- a/src/components/Menu.recent-projects.test.tsx
+++ b/src/components/Menu.recent-projects.test.tsx
@@ -164,7 +164,19 @@ describe('Menu - Recent Projects', () => {
 		});
 		vi.spyOn(SessionManager, 'formatSessionCounts').mockReturnValue('');
 
-		const {lastFrame} = render(
+		const {lastFrame, rerender} = render(
+			<Menu
+				sessionManager={mockSessionManager}
+				worktreeService={mockWorktreeService}
+				onSelectWorktree={vi.fn()}
+				onSelectRecentProject={vi.fn()}
+				multiProject={true}
+				version="test"
+			/>,
+		);
+
+		// Force a rerender to ensure all effects have run
+		rerender(
 			<Menu
 				sessionManager={mockSessionManager}
 				worktreeService={mockWorktreeService}

--- a/src/components/Menu.recent-projects.test.tsx
+++ b/src/components/Menu.recent-projects.test.tsx
@@ -138,6 +138,7 @@ describe('Menu - Recent Projects', () => {
 				worktreeService={mockWorktreeService}
 				onSelectWorktree={vi.fn()}
 				multiProject={false}
+				version="test"
 			/>,
 		);
 
@@ -170,6 +171,7 @@ describe('Menu - Recent Projects', () => {
 				onSelectWorktree={vi.fn()}
 				onSelectRecentProject={vi.fn()}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 
@@ -192,6 +194,7 @@ describe('Menu - Recent Projects', () => {
 				onSelectWorktree={vi.fn()}
 				onSelectRecentProject={vi.fn()}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 
@@ -225,6 +228,7 @@ describe('Menu - Recent Projects', () => {
 				onSelectWorktree={vi.fn()}
 				onSelectRecentProject={vi.fn()}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 
@@ -258,6 +262,7 @@ describe('Menu - Recent Projects', () => {
 				onSelectWorktree={vi.fn()}
 				onSelectRecentProject={vi.fn()}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 
@@ -269,6 +274,7 @@ describe('Menu - Recent Projects', () => {
 				onSelectWorktree={vi.fn()}
 				onSelectRecentProject={vi.fn()}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 
@@ -303,6 +309,7 @@ describe('Menu - Recent Projects', () => {
 				onSelectWorktree={vi.fn()}
 				onSelectRecentProject={vi.fn()}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -119,6 +119,7 @@ describe('Menu component Effect-based error handling', () => {
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
 				onDismissError={onDismissError}
+				version="test"
 			/>,
 		);
 
@@ -167,6 +168,7 @@ describe('Menu component Effect-based error handling', () => {
 				sessionManager={sessionManager}
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
+				version="test"
 			/>,
 		);
 
@@ -219,6 +221,7 @@ describe('Menu component Effect-based error handling', () => {
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
 				onDismissError={onDismissError}
+				version="test"
 			/>,
 		);
 
@@ -262,6 +265,7 @@ describe('Menu component Effect-based error handling', () => {
 				sessionManager={sessionManager}
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
+				version="test"
 			/>,
 		);
 
@@ -309,6 +313,7 @@ describe('Menu component rendering', () => {
 				sessionManager={sessionManager}
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
+				version="test"
 			/>,
 		);
 
@@ -333,6 +338,7 @@ describe('Menu component rendering', () => {
 				sessionManager={sessionManager}
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
+				version="test"
 			/>,
 		);
 
@@ -354,6 +360,7 @@ describe('Menu component rendering', () => {
 				sessionManager={sessionManager}
 				worktreeService={worktreeService}
 				onSelectWorktree={onSelectWorktree}
+				version="test"
 			/>,
 		);
 
@@ -437,6 +444,7 @@ describe('Menu component rendering', () => {
 				onSelectWorktree={onSelectWorktree}
 				onSelectRecentProject={onSelectRecentProject}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 
@@ -503,6 +511,7 @@ describe('Menu component rendering', () => {
 				onSelectWorktree={onSelectWorktree}
 				onSelectRecentProject={onSelectRecentProject}
 				multiProject={true}
+				version="test"
 			/>,
 		);
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -33,6 +33,7 @@ interface MenuProps {
 	onDismissError?: () => void;
 	projectName?: string;
 	multiProject?: boolean;
+	version: string;
 }
 
 interface CommonItem {
@@ -87,6 +88,7 @@ const Menu: React.FC<MenuProps> = ({
 	onDismissError,
 	projectName,
 	multiProject = false,
+	version,
 }) => {
 	const [baseWorktrees, setBaseWorktrees] = useState<Worktree[]>([]);
 	const [defaultBranch, setDefaultBranch] = useState<string | null>(null);
@@ -582,7 +584,7 @@ const Menu: React.FC<MenuProps> = ({
 		<Box flexDirection="column">
 			<Box marginBottom={1} flexDirection="column">
 				<Text bold color="green">
-					CCManager - Claude Code Worktree Manager
+					CCManager - Claude Code Worktree Manager v{version}
 				</Text>
 				{projectName && (
 					<Text bold color="green">

--- a/src/components/TextInputWrapper.tsx
+++ b/src/components/TextInputWrapper.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import TextInput from 'ink-text-input';
+import React, {useState, useEffect, useRef} from 'react';
+import {Text, useInput} from 'ink';
 import stripAnsi from 'strip-ansi';
 
 interface TextInputWrapperProps {
@@ -13,23 +13,206 @@ interface TextInputWrapperProps {
 	highlightPastedText?: boolean;
 }
 
+/**
+ * Custom text input component that handles rapid input correctly.
+ * This is a replacement for ink-text-input that uses refs for immediate
+ * state updates, which is necessary for text expansion tools like Espanso.
+ */
 const TextInputWrapper: React.FC<TextInputWrapperProps> = ({
 	value,
 	onChange,
-	...props
+	onSubmit,
+	placeholder = '',
+	focus = true,
+	mask,
+	showCursor = true,
 }) => {
-	const handleChange = (newValue: string) => {
-		// First strip all ANSI escape sequences
-		let cleanedValue = stripAnsi(newValue);
+	// Use ref to track the actual current value for immediate updates
+	// This is critical for handling rapid input from tools like Espanso
+	const valueRef = useRef(value);
+	const cursorRef = useRef(value.length);
 
-		// Then specifically remove bracketed paste mode markers that might remain
-		// These sometimes appear as literal text after ANSI stripping
-		cleanedValue = cleanedValue.replace(/\[200~/g, '').replace(/\[201~/g, '');
+	// State for triggering re-renders
+	const [, forceUpdate] = useState({});
 
-		onChange(cleanedValue);
+	// Sync refs when value prop changes from parent
+	useEffect(() => {
+		valueRef.current = value;
+		// Adjust cursor if it's beyond the new value length
+		if (cursorRef.current > value.length) {
+			cursorRef.current = value.length;
+		}
+	}, [value]);
+
+	const cleanValue = (val: string): string => {
+		let cleaned = stripAnsi(val);
+		cleaned = cleaned.replace(/\[200~/g, '').replace(/\[201~/g, '');
+		return cleaned;
 	};
 
-	return <TextInput value={value} onChange={handleChange} {...props} />;
+	// Process backspace characters that might be embedded in input string
+	// This handles cases where text expansion tools send backspaces as characters
+	const processBackspaces = (
+		input: string,
+		currentValue: string,
+		cursor: number,
+	): {value: string; cursor: number; remainingInput: string} => {
+		let newValue = currentValue;
+		let newCursor = cursor;
+		let remaining = '';
+
+		for (let i = 0; i < input.length; i++) {
+			const char = input[i];
+			const charCode = char?.charCodeAt(0);
+
+			// Check for backspace characters (ASCII 8 or 127)
+			if (charCode === 8 || charCode === 127) {
+				if (newCursor > 0) {
+					newValue =
+						newValue.slice(0, newCursor - 1) + newValue.slice(newCursor);
+					newCursor--;
+				}
+			} else {
+				// Regular character - add to remaining
+				remaining += char;
+			}
+		}
+
+		return {value: newValue, cursor: newCursor, remainingInput: remaining};
+	};
+
+	useInput(
+		(input, key) => {
+			// Ignore certain keys
+			if (
+				key.upArrow ||
+				key.downArrow ||
+				(key.ctrl && input === 'c') ||
+				key.tab ||
+				(key.shift && key.tab)
+			) {
+				return;
+			}
+
+			// Handle Enter/Return
+			if (key.return) {
+				if (onSubmit) {
+					onSubmit(valueRef.current);
+				}
+				return;
+			}
+
+			let currentValue = valueRef.current;
+			let cursor = cursorRef.current;
+
+			if (key.leftArrow) {
+				if (showCursor && cursor > 0) {
+					cursorRef.current = cursor - 1;
+					forceUpdate({});
+				}
+				return;
+			}
+
+			if (key.rightArrow) {
+				if (showCursor && cursor < currentValue.length) {
+					cursorRef.current = cursor + 1;
+					forceUpdate({});
+				}
+				return;
+			}
+
+			if (key.backspace || key.delete) {
+				if (cursor > 0) {
+					const nextValue =
+						currentValue.slice(0, cursor - 1) + currentValue.slice(cursor);
+					valueRef.current = nextValue;
+					cursorRef.current = cursor - 1;
+					onChange(nextValue);
+					forceUpdate({});
+				}
+				return;
+			}
+
+			// Process input that might contain embedded backspace characters
+			// (some text expansion tools send backspaces as part of the input string)
+			const {
+				value: processedValue,
+				cursor: processedCursor,
+				remainingInput,
+			} = processBackspaces(input, currentValue, cursor);
+
+			currentValue = processedValue;
+			cursor = processedCursor;
+
+			// Add remaining characters (non-backspace)
+			if (remainingInput) {
+				const cleanedInput = cleanValue(remainingInput);
+				if (cleanedInput) {
+					currentValue =
+						currentValue.slice(0, cursor) +
+						cleanedInput +
+						currentValue.slice(cursor);
+					cursor = cursor + cleanedInput.length;
+				}
+			}
+
+			// Update refs immediately (synchronously)
+			valueRef.current = currentValue;
+			cursorRef.current = cursor;
+
+			// Notify parent of value change
+			onChange(currentValue);
+
+			// Force re-render to update display
+			forceUpdate({});
+		},
+		{isActive: focus},
+	);
+
+	// Render the text with cursor
+	const displayValue = mask
+		? mask.repeat(valueRef.current.length)
+		: valueRef.current;
+	const cursor = cursorRef.current;
+
+	if (!showCursor || !focus) {
+		return (
+			<Text>
+				{displayValue.length > 0 ? (
+					displayValue
+				) : placeholder ? (
+					<Text dimColor>{placeholder}</Text>
+				) : null}
+			</Text>
+		);
+	}
+
+	// Show cursor
+	if (displayValue.length === 0) {
+		// Show placeholder with cursor on first char
+		if (placeholder) {
+			return (
+				<Text>
+					<Text inverse>{placeholder[0] || ' '}</Text>
+					<Text dimColor>{placeholder.slice(1)}</Text>
+				</Text>
+			);
+		}
+		return <Text inverse> </Text>;
+	}
+
+	// Render value with cursor
+	const beforeCursor = displayValue.slice(0, cursor);
+	const atCursor = displayValue[cursor] || ' ';
+	const afterCursor = displayValue.slice(cursor + 1);
+
+	return (
+		<Text>
+			{beforeCursor}
+			<Text inverse>{atCursor}</Text>
+			{afterCursor}
+		</Text>
+	);
 };
 
 export default TextInputWrapper;

--- a/src/components/TextInputWrapper.tsx
+++ b/src/components/TextInputWrapper.tsx
@@ -1,5 +1,5 @@
-import React, {useState, useEffect, useRef} from 'react';
-import {Text, useInput} from 'ink';
+import React from 'react';
+import TextInput from 'ink-text-input';
 import stripAnsi from 'strip-ansi';
 
 interface TextInputWrapperProps {
@@ -13,206 +13,23 @@ interface TextInputWrapperProps {
 	highlightPastedText?: boolean;
 }
 
-/**
- * Custom text input component that handles rapid input correctly.
- * This is a replacement for ink-text-input that uses refs for immediate
- * state updates, which is necessary for text expansion tools like Espanso.
- */
 const TextInputWrapper: React.FC<TextInputWrapperProps> = ({
 	value,
 	onChange,
-	onSubmit,
-	placeholder = '',
-	focus = true,
-	mask,
-	showCursor = true,
+	...props
 }) => {
-	// Use ref to track the actual current value for immediate updates
-	// This is critical for handling rapid input from tools like Espanso
-	const valueRef = useRef(value);
-	const cursorRef = useRef(value.length);
+	const handleChange = (newValue: string) => {
+		// First strip all ANSI escape sequences
+		let cleanedValue = stripAnsi(newValue);
 
-	// State for triggering re-renders
-	const [, forceUpdate] = useState({});
+		// Then specifically remove bracketed paste mode markers that might remain
+		// These sometimes appear as literal text after ANSI stripping
+		cleanedValue = cleanedValue.replace(/\[200~/g, '').replace(/\[201~/g, '');
 
-	// Sync refs when value prop changes from parent
-	useEffect(() => {
-		valueRef.current = value;
-		// Adjust cursor if it's beyond the new value length
-		if (cursorRef.current > value.length) {
-			cursorRef.current = value.length;
-		}
-	}, [value]);
-
-	const cleanValue = (val: string): string => {
-		let cleaned = stripAnsi(val);
-		cleaned = cleaned.replace(/\[200~/g, '').replace(/\[201~/g, '');
-		return cleaned;
+		onChange(cleanedValue);
 	};
 
-	// Process backspace characters that might be embedded in input string
-	// This handles cases where text expansion tools send backspaces as characters
-	const processBackspaces = (
-		input: string,
-		currentValue: string,
-		cursor: number,
-	): {value: string; cursor: number; remainingInput: string} => {
-		let newValue = currentValue;
-		let newCursor = cursor;
-		let remaining = '';
-
-		for (let i = 0; i < input.length; i++) {
-			const char = input[i];
-			const charCode = char?.charCodeAt(0);
-
-			// Check for backspace characters (ASCII 8 or 127)
-			if (charCode === 8 || charCode === 127) {
-				if (newCursor > 0) {
-					newValue =
-						newValue.slice(0, newCursor - 1) + newValue.slice(newCursor);
-					newCursor--;
-				}
-			} else {
-				// Regular character - add to remaining
-				remaining += char;
-			}
-		}
-
-		return {value: newValue, cursor: newCursor, remainingInput: remaining};
-	};
-
-	useInput(
-		(input, key) => {
-			// Ignore certain keys
-			if (
-				key.upArrow ||
-				key.downArrow ||
-				(key.ctrl && input === 'c') ||
-				key.tab ||
-				(key.shift && key.tab)
-			) {
-				return;
-			}
-
-			// Handle Enter/Return
-			if (key.return) {
-				if (onSubmit) {
-					onSubmit(valueRef.current);
-				}
-				return;
-			}
-
-			let currentValue = valueRef.current;
-			let cursor = cursorRef.current;
-
-			if (key.leftArrow) {
-				if (showCursor && cursor > 0) {
-					cursorRef.current = cursor - 1;
-					forceUpdate({});
-				}
-				return;
-			}
-
-			if (key.rightArrow) {
-				if (showCursor && cursor < currentValue.length) {
-					cursorRef.current = cursor + 1;
-					forceUpdate({});
-				}
-				return;
-			}
-
-			if (key.backspace || key.delete) {
-				if (cursor > 0) {
-					const nextValue =
-						currentValue.slice(0, cursor - 1) + currentValue.slice(cursor);
-					valueRef.current = nextValue;
-					cursorRef.current = cursor - 1;
-					onChange(nextValue);
-					forceUpdate({});
-				}
-				return;
-			}
-
-			// Process input that might contain embedded backspace characters
-			// (some text expansion tools send backspaces as part of the input string)
-			const {
-				value: processedValue,
-				cursor: processedCursor,
-				remainingInput,
-			} = processBackspaces(input, currentValue, cursor);
-
-			currentValue = processedValue;
-			cursor = processedCursor;
-
-			// Add remaining characters (non-backspace)
-			if (remainingInput) {
-				const cleanedInput = cleanValue(remainingInput);
-				if (cleanedInput) {
-					currentValue =
-						currentValue.slice(0, cursor) +
-						cleanedInput +
-						currentValue.slice(cursor);
-					cursor = cursor + cleanedInput.length;
-				}
-			}
-
-			// Update refs immediately (synchronously)
-			valueRef.current = currentValue;
-			cursorRef.current = cursor;
-
-			// Notify parent of value change
-			onChange(currentValue);
-
-			// Force re-render to update display
-			forceUpdate({});
-		},
-		{isActive: focus},
-	);
-
-	// Render the text with cursor
-	const displayValue = mask
-		? mask.repeat(valueRef.current.length)
-		: valueRef.current;
-	const cursor = cursorRef.current;
-
-	if (!showCursor || !focus) {
-		return (
-			<Text>
-				{displayValue.length > 0 ? (
-					displayValue
-				) : placeholder ? (
-					<Text dimColor>{placeholder}</Text>
-				) : null}
-			</Text>
-		);
-	}
-
-	// Show cursor
-	if (displayValue.length === 0) {
-		// Show placeholder with cursor on first char
-		if (placeholder) {
-			return (
-				<Text>
-					<Text inverse>{placeholder[0] || ' '}</Text>
-					<Text dimColor>{placeholder.slice(1)}</Text>
-				</Text>
-			);
-		}
-		return <Text inverse> </Text>;
-	}
-
-	// Render value with cursor
-	const beforeCursor = displayValue.slice(0, cursor);
-	const atCursor = displayValue[cursor] || ' ';
-	const afterCursor = displayValue.slice(cursor + 1);
-
-	return (
-		<Text>
-			{beforeCursor}
-			<Text inverse>{atCursor}</Text>
-			{afterCursor}
-		</Text>
-	);
+	return <TextInput value={value} onChange={handleChange} {...props} />;
 };
 
 export default TextInputWrapper;

--- a/src/constants/statusIcons.test.ts
+++ b/src/constants/statusIcons.test.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect} from 'vitest';
 import {
 	getStatusDisplay,
+	getBackgroundTaskTag,
 	STATUS_ICONS,
 	STATUS_LABELS,
 	STATUS_TAGS,
@@ -30,37 +31,78 @@ describe('getStatusDisplay', () => {
 	});
 
 	describe('background task indicator', () => {
-		it('should append [BG] badge when idle and hasBackgroundTask is true', () => {
-			const result = getStatusDisplay('idle', true);
+		it('should append [BG] badge when idle and backgroundTaskCount is 1', () => {
+			const result = getStatusDisplay('idle', 1);
 			expect(result).toBe(
 				`${STATUS_ICONS.IDLE} ${STATUS_LABELS.IDLE} ${STATUS_TAGS.BACKGROUND_TASK}`,
 			);
 		});
 
-		it('should not append [BG] badge when idle and hasBackgroundTask is false', () => {
-			const result = getStatusDisplay('idle', false);
+		it('should not append [BG] badge when idle and backgroundTaskCount is 0', () => {
+			const result = getStatusDisplay('idle', 0);
 			expect(result).toBe(`${STATUS_ICONS.IDLE} ${STATUS_LABELS.IDLE}`);
 		});
 
-		it('should append [BG] badge when busy and hasBackgroundTask is true', () => {
-			const result = getStatusDisplay('busy', true);
+		it('should append [BG] badge when busy and backgroundTaskCount is 1', () => {
+			const result = getStatusDisplay('busy', 1);
 			expect(result).toBe(
 				`${STATUS_ICONS.BUSY} ${STATUS_LABELS.BUSY} ${STATUS_TAGS.BACKGROUND_TASK}`,
 			);
 		});
 
-		it('should append [BG] badge when waiting_input and hasBackgroundTask is true', () => {
-			const result = getStatusDisplay('waiting_input', true);
+		it('should append [BG] badge when waiting_input and backgroundTaskCount is 1', () => {
+			const result = getStatusDisplay('waiting_input', 1);
 			expect(result).toBe(
 				`${STATUS_ICONS.WAITING} ${STATUS_LABELS.WAITING} ${STATUS_TAGS.BACKGROUND_TASK}`,
 			);
 		});
 
-		it('should append [BG] badge when pending_auto_approval and hasBackgroundTask is true', () => {
-			const result = getStatusDisplay('pending_auto_approval', true);
+		it('should append [BG] badge when pending_auto_approval and backgroundTaskCount is 1', () => {
+			const result = getStatusDisplay('pending_auto_approval', 1);
 			expect(result).toBe(
 				`${STATUS_ICONS.WAITING} ${STATUS_LABELS.PENDING_AUTO_APPROVAL} ${STATUS_TAGS.BACKGROUND_TASK}`,
 			);
 		});
+
+		it('should append [BG:2] badge when backgroundTaskCount is 2', () => {
+			const result = getStatusDisplay('idle', 2);
+			expect(result).toBe(
+				`${STATUS_ICONS.IDLE} ${STATUS_LABELS.IDLE} \x1b[2m[BG:2]\x1b[0m`,
+			);
+		});
+
+		it('should append [BG:5] badge when backgroundTaskCount is 5', () => {
+			const result = getStatusDisplay('busy', 5);
+			expect(result).toBe(
+				`${STATUS_ICONS.BUSY} ${STATUS_LABELS.BUSY} \x1b[2m[BG:5]\x1b[0m`,
+			);
+		});
+	});
+});
+
+describe('getBackgroundTaskTag', () => {
+	it('should return empty string when count is 0', () => {
+		const result = getBackgroundTaskTag(0);
+		expect(result).toBe('');
+	});
+
+	it('should return empty string when count is negative', () => {
+		expect(getBackgroundTaskTag(-1)).toBe('');
+		expect(getBackgroundTaskTag(-100)).toBe('');
+	});
+
+	it('should return [BG] when count is 1', () => {
+		const result = getBackgroundTaskTag(1);
+		expect(result).toBe(STATUS_TAGS.BACKGROUND_TASK);
+	});
+
+	it('should return [BG:2] when count is 2', () => {
+		const result = getBackgroundTaskTag(2);
+		expect(result).toBe('\x1b[2m[BG:2]\x1b[0m');
+	});
+
+	it('should return [BG:10] when count is 10', () => {
+		const result = getBackgroundTaskTag(10);
+		expect(result).toBe('\x1b[2m[BG:10]\x1b[0m');
 	});
 });

--- a/src/constants/statusIcons.ts
+++ b/src/constants/statusIcons.ts
@@ -17,6 +17,17 @@ export const STATUS_TAGS = {
 	BACKGROUND_TASK: '\x1b[2m[BG]\x1b[0m',
 } as const;
 
+export const getBackgroundTaskTag = (count: number): string => {
+	if (count <= 0) {
+		return '';
+	}
+	if (count === 1) {
+		return STATUS_TAGS.BACKGROUND_TASK;
+	}
+	// count >= 2: show [BG:N]
+	return `\x1b[2m[BG:${count}]\x1b[0m`;
+};
+
 export const MENU_ICONS = {
 	NEW_WORKTREE: '⊕',
 	MERGE_WORKTREE: '⇄',
@@ -40,10 +51,9 @@ const getBaseStatusDisplay = (status: SessionState): string => {
 
 export const getStatusDisplay = (
 	status: SessionState,
-	hasBackgroundTask: boolean = false,
+	backgroundTaskCount: number = 0,
 ): string => {
 	const display = getBaseStatusDisplay(status);
-	return hasBackgroundTask
-		? `${display} ${STATUS_TAGS.BACKGROUND_TASK}`
-		: display;
+	const bgTag = getBackgroundTaskTag(backgroundTaskCount);
+	return bgTag ? `${display} ${bgTag}` : display;
 };

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -83,15 +83,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		return session.stateDetector.detectBackgroundTask(session.terminal);
 	}
 
-	private getTerminalContent(session: Session): string {
-		// Use the new screen capture utility that correctly handles
-		// both normal and alternate screen buffers
-		return getTerminalScreenContent(
-			session.terminal,
-			TERMINAL_CONTENT_MAX_LINES,
-		);
-	}
-
 	private handleAutoApproval(session: Session): void {
 		// Cancel any existing verification before starting a new one
 		this.cancelAutoApprovalVerification(
@@ -107,7 +98,10 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		}));
 
 		// Get terminal content for verification
-		const terminalContent = this.getTerminalContent(session);
+		const terminalContent = getTerminalScreenContent(
+			session.terminal,
+			TERMINAL_CONTENT_MAX_LINES,
+		);
 
 		// Verify if permission is needed
 		void Effect.runPromise(

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -389,6 +389,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			// Write data to virtual terminal
 			session.terminal.write(data);
 
+			// Check for screen clear escape sequence (e.g., from /clear command)
+			// When detected, clear the output history to prevent replaying old content on restore
+			if (data.includes('\x1B[2J')) {
+				session.outputHistory = [];
+			}
+
 			// Store in output history as Buffer
 			const buffer = Buffer.from(data, 'utf8');
 			session.outputHistory.push(buffer);

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -83,6 +83,15 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		return session.stateDetector.detectBackgroundTask(session.terminal);
 	}
 
+	private getTerminalContent(session: Session): string {
+		// Use the new screen capture utility that correctly handles
+		// both normal and alternate screen buffers
+		return getTerminalScreenContent(
+			session.terminal,
+			TERMINAL_CONTENT_MAX_LINES,
+		);
+	}
+
 	private handleAutoApproval(session: Session): void {
 		// Cancel any existing verification before starting a new one
 		this.cancelAutoApprovalVerification(
@@ -98,10 +107,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		}));
 
 		// Get terminal content for verification
-		const terminalContent = getTerminalScreenContent(
-			session.terminal,
-			TERMINAL_CONTENT_MAX_LINES,
-		);
+		const terminalContent = this.getTerminalContent(session);
 
 		// Verify if permission is needed
 		void Effect.runPromise(

--- a/src/services/stateDetector/base.ts
+++ b/src/services/stateDetector/base.ts
@@ -36,5 +36,5 @@ export abstract class BaseStateDetector implements StateDetector {
 		return this.getTerminalLines(terminal, maxLines).join('\n');
 	}
 
-	abstract detectBackgroundTask(terminal: Terminal): boolean;
+	abstract detectBackgroundTask(terminal: Terminal): number;
 }

--- a/src/services/stateDetector/base.ts
+++ b/src/services/stateDetector/base.ts
@@ -1,5 +1,6 @@
 import {SessionState, Terminal} from '../../types/index.js';
 import {StateDetector} from './types.js';
+import {getTerminalScreenContent} from '../../utils/screenCapture.js';
 
 export abstract class BaseStateDetector implements StateDetector {
 	abstract detectState(
@@ -11,29 +12,15 @@ export abstract class BaseStateDetector implements StateDetector {
 		terminal: Terminal,
 		maxLines: number = 30,
 	): string[] {
-		const buffer = terminal.buffer.active;
-		const lines: string[] = [];
-
-		// Start from the bottom and work our way up
-		for (let i = buffer.length - 1; i >= 0 && lines.length < maxLines; i--) {
-			const line = buffer.getLine(i);
-			if (line) {
-				const text = line.translateToString(true);
-				// Skip empty lines at the bottom
-				if (lines.length > 0 || text.trim() !== '') {
-					lines.unshift(text);
-				}
-			}
-		}
-
-		return lines;
+		const content = getTerminalScreenContent(terminal, maxLines);
+		return content.split('\n');
 	}
 
 	protected getTerminalContent(
 		terminal: Terminal,
 		maxLines: number = 30,
 	): string {
-		return this.getTerminalLines(terminal, maxLines).join('\n');
+		return getTerminalScreenContent(terminal, maxLines);
 	}
 
 	abstract detectBackgroundTask(terminal: Terminal): number;

--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -491,6 +491,61 @@ describe('ClaudeStateDetector', () => {
 			expect(count).toBe(1);
 		});
 
+		it('should return count 3 when "3 local agents" is in status bar', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Some output',
+				'More output',
+				'bypass permissions on - 3 local agents',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(3);
+		});
+
+		it('should return count 1 when "1 local agent" is in status bar', () => {
+			// Arrange
+			terminal = createMockTerminal(['Some output', '1 local agent']);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(1);
+		});
+
+		it('should detect local agent count case-insensitively', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Output line 1',
+				'Output line 2',
+				'2 LOCAL AGENTS running',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(2);
+		});
+
+		it('should prioritize explicit count from "N local agents" over "(running)"', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Some output',
+				'3 local agents | task1 (running)',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(3);
+		});
+
 		it('should prioritize count from "N background task" over "(running)"', () => {
 			// Arrange - both patterns present, count should be from explicit pattern
 			terminal = createMockTerminal([

--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -279,7 +279,7 @@ describe('ClaudeStateDetector', () => {
 	});
 
 	describe('detectBackgroundTask', () => {
-		it('should detect background task when pattern is in last 3 lines (status bar)', () => {
+		it('should return count 1 when "1 background task" is in status bar', () => {
 			// Arrange
 			terminal = createMockTerminal([
 				'Previous conversation content',
@@ -289,13 +289,13 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(true);
+			expect(count).toBe(1);
 		});
 
-		it('should detect background task with plural "background tasks"', () => {
+		it('should return count 2 when "2 background tasks" is in status bar', () => {
 			// Arrange
 			terminal = createMockTerminal([
 				'Some output',
@@ -304,13 +304,28 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(true);
+			expect(count).toBe(2);
 		});
 
-		it('should detect background task case-insensitively', () => {
+		it('should return count 3 when "3 background tasks" is in status bar', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Some output',
+				'More output',
+				'3 background tasks | build, test, lint',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(3);
+		});
+
+		it('should detect background task count case-insensitively', () => {
 			// Arrange
 			terminal = createMockTerminal([
 				'Output line 1',
@@ -319,13 +334,13 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(true);
+			expect(count).toBe(1);
 		});
 
-		it('should return false when no background task pattern in last 3 lines', () => {
+		it('should return 0 when no background task pattern in last 3 lines', () => {
 			// Arrange
 			terminal = createMockTerminal([
 				'Command completed successfully',
@@ -334,10 +349,10 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(false);
+			expect(count).toBe(0);
 		});
 
 		it('should not detect background task when pattern is in conversation content (not status bar)', () => {
@@ -352,21 +367,21 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert - should only check last 3 lines, not the conversation content
-			expect(hasBackgroundTask).toBe(false);
+			expect(count).toBe(0);
 		});
 
-		it('should handle empty terminal', () => {
+		it('should return 0 for empty terminal', () => {
 			// Arrange
 			terminal = createMockTerminal([]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(false);
+			expect(count).toBe(0);
 		});
 
 		it('should handle terminal with fewer than 3 lines', () => {
@@ -374,13 +389,13 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['1 background task']);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(true);
+			expect(count).toBe(1);
 		});
 
-		it('should detect "(running)" status bar indicator', () => {
+		it('should return 1 when "(running)" status bar indicator is present', () => {
 			// Arrange
 			terminal = createMockTerminal([
 				'Some conversation output',
@@ -389,10 +404,10 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(true);
+			expect(count).toBe(1);
 		});
 
 		it('should detect "(running)" case-insensitively', () => {
@@ -400,10 +415,24 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['Some output', 'command name (RUNNING)']);
 
 			// Act
-			const hasBackgroundTask = detector.detectBackgroundTask(terminal);
+			const count = detector.detectBackgroundTask(terminal);
 
 			// Assert
-			expect(hasBackgroundTask).toBe(true);
+			expect(count).toBe(1);
+		});
+
+		it('should prioritize count from "N background task" over "(running)"', () => {
+			// Arrange - both patterns present, count should be from explicit pattern
+			terminal = createMockTerminal([
+				'Some output',
+				'3 background tasks | task1, task2 (running)',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(3);
 		});
 	});
 });

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -41,7 +41,9 @@ export class ClaudeStateDetector extends BaseStateDetector {
 		const content = lines.join('\n').toLowerCase();
 
 		// Check for "N background task(s)" pattern first (content already lowercased)
-		const countMatch = content.match(/(\d+)\s+background\s+task/);
+		const countMatch = content.match(
+			/(\d+)\s+(?:background\s+task|local\s+agent)/,
+		);
 		if (countMatch?.[1]) {
 			return parseInt(countMatch[1], 10);
 		}

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -36,12 +36,22 @@ export class ClaudeStateDetector extends BaseStateDetector {
 		return 'idle';
 	}
 
-	detectBackgroundTask(terminal: Terminal): boolean {
+	detectBackgroundTask(terminal: Terminal): number {
 		const lines = this.getTerminalLines(terminal, 3);
 		const content = lines.join('\n').toLowerCase();
-		// Detect background task patterns:
-		// - "N background task(s)" in status bar
-		// - "(running)" in status bar for active background commands
-		return content.includes('background task') || content.includes('(running)');
+
+		// Check for "N background task(s)" pattern first (content already lowercased)
+		const countMatch = content.match(/(\d+)\s+background\s+task/);
+		if (countMatch?.[1]) {
+			return parseInt(countMatch[1], 10);
+		}
+
+		// Check for "(running)" pattern - indicates at least 1 background task
+		if (content.includes('(running)')) {
+			return 1;
+		}
+
+		// No background task detected
+		return 0;
 	}
 }

--- a/src/services/stateDetector/cline.ts
+++ b/src/services/stateDetector/cline.ts
@@ -33,7 +33,7 @@ export class ClineStateDetector extends BaseStateDetector {
 		return 'busy';
 	}
 
-	detectBackgroundTask(_terminal: Terminal): boolean {
-		return false;
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
 	}
 }

--- a/src/services/stateDetector/codex.ts
+++ b/src/services/stateDetector/codex.ts
@@ -40,7 +40,7 @@ export class CodexStateDetector extends BaseStateDetector {
 		return 'idle';
 	}
 
-	detectBackgroundTask(_terminal: Terminal): boolean {
-		return false;
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
 	}
 }

--- a/src/services/stateDetector/cursor.ts
+++ b/src/services/stateDetector/cursor.ts
@@ -24,7 +24,7 @@ export class CursorStateDetector extends BaseStateDetector {
 		return 'idle';
 	}
 
-	detectBackgroundTask(_terminal: Terminal): boolean {
-		return false;
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
 	}
 }

--- a/src/services/stateDetector/gemini.ts
+++ b/src/services/stateDetector/gemini.ts
@@ -39,7 +39,7 @@ export class GeminiStateDetector extends BaseStateDetector {
 		return 'idle';
 	}
 
-	detectBackgroundTask(_terminal: Terminal): boolean {
-		return false;
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
 	}
 }

--- a/src/services/stateDetector/github-copilot.ts
+++ b/src/services/stateDetector/github-copilot.ts
@@ -25,7 +25,7 @@ export class GitHubCopilotStateDetector extends BaseStateDetector {
 		return 'idle';
 	}
 
-	detectBackgroundTask(_terminal: Terminal): boolean {
-		return false;
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
 	}
 }

--- a/src/services/stateDetector/opencode.ts
+++ b/src/services/stateDetector/opencode.ts
@@ -20,7 +20,7 @@ export class OpenCodeStateDetector extends BaseStateDetector {
 		return 'idle';
 	}
 
-	detectBackgroundTask(_terminal: Terminal): boolean {
-		return false;
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
 	}
 }

--- a/src/services/stateDetector/testUtils.ts
+++ b/src/services/stateDetector/testUtils.ts
@@ -3,17 +3,31 @@ import type {Terminal} from '../../types/index.js';
 /**
  * Creates a mock Terminal object for testing state detectors.
  * @param lines - Array of strings representing terminal output lines
+ * @param options - Optional configuration for rows, cols, and baseY
  * @returns Mock Terminal object with buffer interface
  */
-export const createMockTerminal = (lines: string[]): Terminal => {
+export const createMockTerminal = (
+	lines: string[],
+	options?: {rows?: number; cols?: number; baseY?: number},
+): Terminal => {
+	const rows = options?.rows ?? lines.length;
+	const cols = options?.cols ?? 80;
+	const baseY = options?.baseY ?? 0;
+
 	const buffer = {
 		length: lines.length,
 		active: {
+			type: 'normal',
 			length: lines.length,
+			baseY,
 			getLine: (index: number) => {
 				if (index >= 0 && index < lines.length) {
 					return {
-						translateToString: () => lines[index],
+						translateToString: (
+							_trimRight?: boolean,
+							_startCol?: number,
+							_endCol?: number,
+						) => lines[index],
 					};
 				}
 				return null;
@@ -21,5 +35,5 @@ export const createMockTerminal = (lines: string[]): Terminal => {
 		},
 	};
 
-	return {buffer} as unknown as Terminal;
+	return {buffer, rows, cols} as unknown as Terminal;
 };

--- a/src/services/stateDetector/testUtils.ts
+++ b/src/services/stateDetector/testUtils.ts
@@ -3,16 +3,9 @@ import type {Terminal} from '../../types/index.js';
 /**
  * Creates a mock Terminal object for testing state detectors.
  * @param lines - Array of strings representing terminal output lines
- * @param options - Optional configuration for rows and cols
  * @returns Mock Terminal object with buffer interface
  */
-export const createMockTerminal = (
-	lines: string[],
-	options?: {rows?: number; cols?: number},
-): Terminal => {
-	const rows = options?.rows ?? lines.length;
-	const cols = options?.cols ?? 80;
-
+export const createMockTerminal = (lines: string[]): Terminal => {
 	const buffer = {
 		length: lines.length,
 		active: {
@@ -20,11 +13,7 @@ export const createMockTerminal = (
 			getLine: (index: number) => {
 				if (index >= 0 && index < lines.length) {
 					return {
-						translateToString: (
-							_trimRight?: boolean,
-							_startCol?: number,
-							_endCol?: number,
-						) => lines[index],
+						translateToString: () => lines[index],
 					};
 				}
 				return null;
@@ -32,5 +21,5 @@ export const createMockTerminal = (
 		},
 	};
 
-	return {buffer, rows, cols} as unknown as Terminal;
+	return {buffer} as unknown as Terminal;
 };

--- a/src/services/stateDetector/testUtils.ts
+++ b/src/services/stateDetector/testUtils.ts
@@ -3,9 +3,16 @@ import type {Terminal} from '../../types/index.js';
 /**
  * Creates a mock Terminal object for testing state detectors.
  * @param lines - Array of strings representing terminal output lines
+ * @param options - Optional configuration for rows and cols
  * @returns Mock Terminal object with buffer interface
  */
-export const createMockTerminal = (lines: string[]): Terminal => {
+export const createMockTerminal = (
+	lines: string[],
+	options?: {rows?: number; cols?: number},
+): Terminal => {
+	const rows = options?.rows ?? lines.length;
+	const cols = options?.cols ?? 80;
+
 	const buffer = {
 		length: lines.length,
 		active: {
@@ -13,7 +20,11 @@ export const createMockTerminal = (lines: string[]): Terminal => {
 			getLine: (index: number) => {
 				if (index >= 0 && index < lines.length) {
 					return {
-						translateToString: () => lines[index],
+						translateToString: (
+							_trimRight?: boolean,
+							_startCol?: number,
+							_endCol?: number,
+						) => lines[index],
 					};
 				}
 				return null;
@@ -21,5 +32,5 @@ export const createMockTerminal = (lines: string[]): Terminal => {
 		},
 	};
 
-	return {buffer} as unknown as Terminal;
+	return {buffer, rows, cols} as unknown as Terminal;
 };

--- a/src/services/stateDetector/types.ts
+++ b/src/services/stateDetector/types.ts
@@ -2,5 +2,5 @@ import {SessionState, Terminal} from '../../types/index.js';
 
 export interface StateDetector {
 	detectState(terminal: Terminal, currentState: SessionState): SessionState;
-	detectBackgroundTask(terminal: Terminal): boolean;
+	detectBackgroundTask(terminal: Terminal): number;
 }

--- a/src/services/worktreeService.submodule.test.ts
+++ b/src/services/worktreeService.submodule.test.ts
@@ -1,0 +1,101 @@
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {execSync} from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import {Effect} from 'effect';
+import {WorktreeService} from './worktreeService.js';
+
+describe('WorktreeService with submodules', () => {
+	// Use os.tmpdir() and unique suffix to avoid conflicts with parallel tests
+	// Use realpathSync to resolve symlinks (e.g., /var -> /private/var on macOS)
+	const testDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'ccmanager-ws-submodule-test-')),
+	);
+	const rootProjectDir = path.join(testDir, 'root-project');
+	const submodule1Dir = path.join(rootProjectDir, 'modules', 'submodule-1');
+
+	beforeAll(() => {
+		// Allow file:// protocol for local submodule cloning (needed for CI)
+		execSync('git config --global protocol.file.allow always');
+
+		// Clean up if exists
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+
+		// Create test directory structure
+		fs.mkdirSync(testDir, {recursive: true});
+
+		// Create submodule source repository
+		const submodule1Source = path.join(testDir, 'submodule-1-source');
+		fs.mkdirSync(submodule1Source, {recursive: true});
+		execSync('git init', {cwd: submodule1Source});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: submodule1Source});
+		execSync('git config user.name "Test User"', {cwd: submodule1Source});
+		fs.writeFileSync(path.join(submodule1Source, 'README.md'), '# Submodule 1');
+		execSync('git add README.md', {cwd: submodule1Source});
+		execSync('git commit -m "Initial commit"', {cwd: submodule1Source});
+
+		// Create root project
+		fs.mkdirSync(rootProjectDir, {recursive: true});
+		execSync('git init', {cwd: rootProjectDir});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: rootProjectDir});
+		execSync('git config user.name "Test User"', {cwd: rootProjectDir});
+		fs.writeFileSync(path.join(rootProjectDir, 'README.md'), '# Root Project');
+		execSync('git add README.md', {cwd: rootProjectDir});
+		execSync('git commit -m "Initial commit"', {cwd: rootProjectDir});
+
+		// Add submodule
+		execSync(`git submodule add ${submodule1Source} modules/submodule-1`, {
+			cwd: rootProjectDir,
+		});
+		execSync('git commit -m "Add submodule"', {cwd: rootProjectDir});
+	});
+
+	afterAll(() => {
+		// Clean up
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+	});
+
+	it('should return the submodule working directory from getGitRootPath()', () => {
+		const service = new WorktreeService(submodule1Dir);
+		const result = service.getGitRootPath();
+
+		// Should return the submodule's working directory
+		expect(result).toBe(submodule1Dir);
+
+		// Should NOT return a path containing .git/modules
+		expect(result).not.toContain('.git/modules');
+	});
+
+	it('should still work for regular repositories', () => {
+		const service = new WorktreeService(rootProjectDir);
+		const result = service.getGitRootPath();
+
+		expect(result).toBe(rootProjectDir);
+		expect(path.basename(result)).toBe('root-project');
+	});
+
+	it('should return worktrees with correct paths (not .git/modules paths) for submodules', async () => {
+		const service = new WorktreeService(submodule1Dir);
+		const worktrees = await Effect.runPromise(service.getWorktreesEffect());
+
+		// Should have at least one worktree
+		expect(worktrees.length).toBeGreaterThan(0);
+
+		// The main worktree path should be the submodule working directory
+		const mainWorktree = worktrees.find(wt => wt.isMainWorktree);
+		expect(mainWorktree).toBeDefined();
+		expect(mainWorktree!.path).toBe(submodule1Dir);
+
+		// No worktree should have .git/modules in its path
+		for (const wt of worktrees) {
+			expect(wt.path).not.toContain('.git/modules');
+		}
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -272,16 +272,18 @@ export interface RemoteBranchMatch {
 }
 
 export class AmbiguousBranchError extends Error {
-	constructor(
-		public branchName: string,
-		public matches: RemoteBranchMatch[],
-	) {
+	branchName: string;
+	matches: RemoteBranchMatch[];
+
+	constructor(branchName: string, matches: RemoteBranchMatch[]) {
 		super(
 			`Ambiguous branch '${branchName}' found in multiple remotes: ${matches
 				.map(m => m.fullRef)
 				.join(', ')}. Please specify which remote to use.`,
 		);
 		this.name = 'AmbiguousBranchError';
+		this.branchName = branchName;
+		this.matches = matches;
 	}
 }
 

--- a/src/utils/gitUtils.submodule.test.ts
+++ b/src/utils/gitUtils.submodule.test.ts
@@ -1,0 +1,81 @@
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {execSync} from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import {getGitRepositoryRoot} from './gitUtils.js';
+
+describe('getGitRepositoryRoot with submodules', () => {
+	// Use os.tmpdir() and unique suffix to avoid conflicts with parallel tests
+	// Use realpathSync to resolve symlinks (e.g., /var -> /private/var on macOS)
+	const testDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'ccmanager-submodule-test-')),
+	);
+	const rootProjectDir = path.join(testDir, 'root-project');
+	const submodule1Dir = path.join(rootProjectDir, 'modules', 'submodule-1');
+
+	beforeAll(() => {
+		// Allow file:// protocol for local submodule cloning (needed for CI)
+		execSync('git config --global protocol.file.allow always');
+
+		// Clean up if exists
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+
+		// Create test directory structure
+		fs.mkdirSync(testDir, {recursive: true});
+
+		// Create submodule source repository
+		const submodule1Source = path.join(testDir, 'submodule-1-source');
+		fs.mkdirSync(submodule1Source, {recursive: true});
+		execSync('git init', {cwd: submodule1Source});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: submodule1Source});
+		execSync('git config user.name "Test User"', {cwd: submodule1Source});
+		fs.writeFileSync(path.join(submodule1Source, 'README.md'), '# Submodule 1');
+		execSync('git add README.md', {cwd: submodule1Source});
+		execSync('git commit -m "Initial commit"', {cwd: submodule1Source});
+
+		// Create root project
+		fs.mkdirSync(rootProjectDir, {recursive: true});
+		execSync('git init', {cwd: rootProjectDir});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: rootProjectDir});
+		execSync('git config user.name "Test User"', {cwd: rootProjectDir});
+		fs.writeFileSync(path.join(rootProjectDir, 'README.md'), '# Root Project');
+		execSync('git add README.md', {cwd: rootProjectDir});
+		execSync('git commit -m "Initial commit"', {cwd: rootProjectDir});
+
+		// Add submodule
+		execSync(`git submodule add ${submodule1Source} modules/submodule-1`, {
+			cwd: rootProjectDir,
+		});
+		execSync('git commit -m "Add submodule"', {cwd: rootProjectDir});
+	});
+
+	afterAll(() => {
+		// Clean up
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+	});
+
+	it('should return the submodule working directory, not the parent .git/modules path', () => {
+		// When running from within a submodule
+		const result = getGitRepositoryRoot(submodule1Dir);
+
+		// Should return the submodule's working directory
+		expect(result).toBe(submodule1Dir);
+
+		// Should NOT return a path containing .git/modules
+		expect(result).not.toContain('.git/modules');
+	});
+
+	it('should still work for regular repositories', () => {
+		const result = getGitRepositoryRoot(rootProjectDir);
+
+		expect(result).toBe(rootProjectDir);
+		expect(path.basename(result!)).toBe('root-project');
+	});
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,15 +16,17 @@ interface LoggerConfig {
 }
 
 /**
- * Log level enum for structured logging
+ * Log level constants for structured logging
  */
-enum LogLevel {
-	DEBUG = 'DEBUG',
-	INFO = 'INFO',
-	WARN = 'WARN',
-	ERROR = 'ERROR',
-	LOG = 'LOG',
-}
+const LogLevel = {
+	DEBUG: 'DEBUG',
+	INFO: 'INFO',
+	WARN: 'WARN',
+	ERROR: 'ERROR',
+	LOG: 'LOG',
+} as const;
+
+type LogLevelValue = (typeof LogLevel)[keyof typeof LogLevel];
 
 /**
  * CLI-optimized logger with size management and rotation
@@ -174,7 +176,7 @@ class Logger {
 	/**
 	 * Write log entry with level and formatted message
 	 */
-	private writeLog(level: LogLevel, args: unknown[]): void {
+	private writeLog(level: LogLevelValue, args: unknown[]): void {
 		this.queueWrite(() => {
 			try {
 				this.rotateLogIfNeeded();

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -89,7 +89,7 @@ export interface SessionStateData {
 	autoApprovalFailed: boolean;
 	autoApprovalReason: string | undefined;
 	autoApprovalAbortController: AbortController | undefined;
-	hasBackgroundTask: boolean;
+	backgroundTaskCount: number;
 }
 
 /**
@@ -103,6 +103,6 @@ export function createInitialSessionStateData(): SessionStateData {
 		autoApprovalFailed: false,
 		autoApprovalReason: undefined,
 		autoApprovalAbortController: undefined,
-		hasBackgroundTask: false,
+		backgroundTaskCount: 0,
 	};
 }

--- a/src/utils/screenCapture.ts
+++ b/src/utils/screenCapture.ts
@@ -30,10 +30,14 @@ export function captureScreen(terminal: Terminal): ScreenState {
 	const buffer = terminal.buffer.active;
 	const lines: string[] = [];
 
-	// Capture only the visible screen area (terminal.rows lines)
-	// This works correctly for both normal and alternate screen buffers
+	// baseY is the offset of the viewport within the buffer
+	// For alternate buffer: baseY is always 0
+	// For normal buffer: baseY indicates how much has been scrolled
+	const baseY = buffer.baseY;
+
+	// Capture the visible viewport (not the beginning of scrollback)
 	for (let y = 0; y < terminal.rows; y++) {
-		const line = buffer.getLine(y);
+		const line = buffer.getLine(baseY + y);
 		lines.push(lineToString(line, terminal.cols));
 	}
 

--- a/src/utils/worktreeUtils.submodule.test.ts
+++ b/src/utils/worktreeUtils.submodule.test.ts
@@ -1,0 +1,85 @@
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {execSync} from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import {generateWorktreeDirectory} from './worktreeUtils.js';
+
+describe('generateWorktreeDirectory with submodules', () => {
+	// Use os.tmpdir() and unique suffix to avoid conflicts with parallel tests
+	// Use realpathSync to resolve symlinks (e.g., /var -> /private/var on macOS)
+	const testDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'ccmanager-wt-submodule-test-')),
+	);
+	const rootProjectDir = path.join(testDir, 'root-project');
+	const submodule1Dir = path.join(rootProjectDir, 'modules', 'submodule-1');
+
+	beforeAll(() => {
+		// Allow file:// protocol for local submodule cloning (needed for CI)
+		execSync('git config --global protocol.file.allow always');
+
+		// Clean up if exists
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+
+		// Create test directory structure
+		fs.mkdirSync(testDir, {recursive: true});
+
+		// Create submodule source repository
+		const submodule1Source = path.join(testDir, 'submodule-1-source');
+		fs.mkdirSync(submodule1Source, {recursive: true});
+		execSync('git init', {cwd: submodule1Source});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: submodule1Source});
+		execSync('git config user.name "Test User"', {cwd: submodule1Source});
+		fs.writeFileSync(path.join(submodule1Source, 'README.md'), '# Submodule 1');
+		execSync('git add README.md', {cwd: submodule1Source});
+		execSync('git commit -m "Initial commit"', {cwd: submodule1Source});
+
+		// Create root project
+		fs.mkdirSync(rootProjectDir, {recursive: true});
+		execSync('git init', {cwd: rootProjectDir});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: rootProjectDir});
+		execSync('git config user.name "Test User"', {cwd: rootProjectDir});
+		fs.writeFileSync(path.join(rootProjectDir, 'README.md'), '# Root Project');
+		execSync('git add README.md', {cwd: rootProjectDir});
+		execSync('git commit -m "Initial commit"', {cwd: rootProjectDir});
+
+		// Add submodule
+		execSync(`git submodule add ${submodule1Source} modules/submodule-1`, {
+			cwd: rootProjectDir,
+		});
+		execSync('git commit -m "Add submodule"', {cwd: rootProjectDir});
+	});
+
+	afterAll(() => {
+		// Clean up
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+	});
+
+	it('should use submodule name (not "modules") in {project} placeholder', () => {
+		const result = generateWorktreeDirectory(
+			submodule1Dir,
+			'feature/test',
+			'../worktrees/{project}-{branch}',
+		);
+
+		// Should contain "submodule-1", not "modules"
+		expect(result).toContain('submodule-1');
+		expect(result).not.toContain('modules-');
+	});
+
+	it('should work correctly for regular repositories', () => {
+		const result = generateWorktreeDirectory(
+			rootProjectDir,
+			'feature/test',
+			'../worktrees/{project}-{branch}',
+		);
+
+		expect(result).toContain('root-project');
+	});
+});

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -119,7 +119,7 @@ export function prepareWorktreeItems(
 		const session = sessions.find(s => s.worktreePath === wt.path);
 		const stateData = session?.stateMutex.getSnapshot();
 		const status = stateData
-			? ` [${getStatusDisplay(stateData.state, stateData.hasBackgroundTask)}]`
+			? ` [${getStatusDisplay(stateData.state, stateData.backgroundTaskCount)}]`
 			: '';
 		const fullBranchName = wt.branch
 			? wt.branch.replace('refs/heads/', '')

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -50,6 +50,16 @@ function getGitRepositoryName(projectPath: string): string {
 			? gitCommonDir
 			: path.resolve(projectPath, gitCommonDir);
 
+		// Handle submodule paths: if path contains .git/modules, use --show-toplevel
+		// to get the submodule's actual working directory
+		if (absoluteGitCommonDir.includes('.git/modules')) {
+			const toplevel = execSync('git rev-parse --show-toplevel', {
+				cwd: projectPath,
+				encoding: 'utf8',
+			}).trim();
+			return path.basename(toplevel);
+		}
+
 		const mainWorkingDir = path.dirname(absoluteGitCommonDir);
 
 		return path.basename(mainWorkingDir);


### PR DESCRIPTION
## Summary
- Claude Code now shows background tasks as "N local agents" instead of "N background tasks" in the status bar
- Updated regex in `ClaudeStateDetector.detectBackgroundTask` to match both old and new formats
- Added 4 new tests covering the "local agents" pattern

## Test plan
- [x] All 35 stateDetector tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)